### PR TITLE
Combine orchestrators

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,11 +19,11 @@ import requests
 from app.services.companies_house_enhanced import EnhancedCompaniesHouseAPI, get_enhanced_companies_house_result
 
 # Import the Educational KYC Orchestrator
+from app.services.combined_orchestrator import CombinedEducationalKYCOrchestrator
 from app.services.education_kyc_orchestrator import (
-    UKEducationalKYCOrchestrator, 
     EducationalProviderRequest,
     ProviderType,
-    EducationalVerificationResult
+    EducationalVerificationResult,
 )
 
 # In-memory storage for demo
@@ -216,7 +216,7 @@ async def process_orchestrated_kyc(verification_id: str, provider_data: Dict):
             return
         
         # Create orchestrator
-        orchestrator = UKEducationalKYCOrchestrator()
+        orchestrator = CombinedEducationalKYCOrchestrator()
         
         # Create educational provider request
         educational_request = EducationalProviderRequest(
@@ -626,9 +626,9 @@ async def validate_ukprn_endpoint(ukprn: str):
             }
         
         # Import orchestrator to use UKPRN validation
-        from app.services.education_kyc_orchestrator import UKEducationalKYCOrchestrator
-        
-        orchestrator = UKEducationalKYCOrchestrator()
+        from app.services.combined_orchestrator import CombinedEducationalKYCOrchestrator
+
+        orchestrator = CombinedEducationalKYCOrchestrator()
         
         # Check if scraping dependencies are available
         if not orchestrator._check_scraping_dependencies():
@@ -683,9 +683,9 @@ async def validate_urn_endpoint(urn: str):
             }
         
         # Import orchestrator to use URN validation
-        from app.services.education_kyc_orchestrator import UKEducationalKYCOrchestrator
-        
-        orchestrator = UKEducationalKYCOrchestrator()
+        from app.services.combined_orchestrator import CombinedEducationalKYCOrchestrator
+
+        orchestrator = CombinedEducationalKYCOrchestrator()
         
         # Check if scraping dependencies are available
         if not orchestrator._check_scraping_dependencies():

--- a/app/services/combined_orchestrator.py
+++ b/app/services/combined_orchestrator.py
@@ -1,0 +1,70 @@
+# app/services/combined_orchestrator.py
+"""Combined orchestrator that reuses real API integrations when available
+while falling back to the default educational orchestrator logic."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .education_kyc_orchestrator import (
+    UKEducationalKYCOrchestrator,
+    EducationalProviderRequest,
+    EducationalVerificationResult,
+)
+from .real_kyc_orchestrator import (
+    RealEducationalKYCOrchestrator,
+    VerificationResult,
+)
+
+
+class CombinedEducationalKYCOrchestrator(UKEducationalKYCOrchestrator):
+    """Orchestrator combining real API integrations with educational checks."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Real orchestrator provides API clients. It is used when configured.
+        self.real = RealEducationalKYCOrchestrator()
+
+    # Internal helper -----------------------------------------------------
+    def _convert_real(self, result: VerificationResult, check_type: Optional[str] = None) -> EducationalVerificationResult:
+        """Convert a result from the real orchestrator to the educational format."""
+        return EducationalVerificationResult(
+            check_type=check_type or result.check_type,
+            status=result.status.value,
+            risk_score=result.risk_score,
+            data_source=result.data_source,
+            timestamp=result.timestamp,
+            details=result.details,
+            recommendations=result.recommendations,
+        )
+
+    # Overrides -----------------------------------------------------------
+    async def verify_company_registration(self, request: EducationalProviderRequest) -> EducationalVerificationResult:
+        if self.real.companies_house:
+            real_res = await self.real.companies_house.verify_company(
+                request.company_number,
+                request.organisation_name,
+            )
+            return self._convert_real(real_res, "company_registration")
+        return await super().verify_company_registration(request)
+
+    async def validate_ukprn(self, request: EducationalProviderRequest) -> EducationalVerificationResult:
+        if self.real.ukrlp and request.ukprn:
+            real_res = await self.real.ukrlp.verify_ukprn(
+                request.ukprn,
+                request.organisation_name,
+            )
+            return self._convert_real(real_res, "ukprn_validation")
+        return await super().validate_ukprn(request)
+
+    async def check_sanctions(self, request: EducationalProviderRequest) -> EducationalVerificationResult:
+        if self.real.sanctions:
+            real_res = await self.real.sanctions.check_sanctions(request.organisation_name)
+            return self._convert_real(real_res, "sanctions_screening")
+        return await super().check_sanctions(request)
+
+    async def check_ofqual_recognition(self, request: EducationalProviderRequest) -> EducationalVerificationResult:
+        # Always available in real orchestrator as it does not require config
+        real_res = await self.real.ofqual.verify_awarding_organisation(request.organisation_name)
+        return self._convert_real(real_res, "ofqual_recognition")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ python-dateutil==2.8.2
 # Web scraping for Ofsted data
 beautifulsoup4==4.12.2
 lxml==4.9.3
+structlog==23.3.0


### PR DESCRIPTION
## Summary
- implement `CombinedEducationalKYCOrchestrator` that wraps real API clients and falls back to existing logic
- update `main.py` to use new orchestrator for provider processing and validation endpoints
- add `structlog` to dependencies
- clean unused import

## Testing
- `python -m py_compile app/services/combined_orchestrator.py app/main.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68820f56b0ac832ca59aab96927d86ff