### PR TITLE
Add awarding organisation search via Ofqual API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,9 @@ import uuid
 import aiohttp
 import requests
 
+# Ofqual awarding organisation search
+from app.services.ofqual_awarding_orgs import OfqualAOSearchClient
+
 # Import the enhanced Companies House service (for quick checks)
 from app.services.companies_house_enhanced import EnhancedCompaniesHouseAPI, get_enhanced_companies_house_result
 
@@ -754,6 +757,22 @@ async def validate_ukprn_endpoint(ukprn: str):
             "ukprn": ukprn,
             "error": f"Validation failed: {str(e)}"
         }
+
+
+@app.get("/ofqual/awarding-organisations", response_class=HTMLResponse)
+async def search_awarding_organisations(request: Request, subject: Optional[str] = None, course: Optional[str] = None):
+    """Retrieve awarding organisations from Ofqual based on subject or course."""
+    client = OfqualAOSearchClient()
+    organisations = await client.search(subject=subject, course=course)
+    return templates.TemplateResponse(
+        "awarding_organisations.html",
+        {
+            "request": request,
+            "organisations": organisations,
+            "subject": subject,
+            "course": course,
+        },
+    )
 
 @app.get("/urn/validate/{urn}")
 async def validate_urn_endpoint(urn: str):

--- a/app/services/ofqual_awarding_orgs.py
+++ b/app/services/ofqual_awarding_orgs.py
@@ -1,0 +1,31 @@
+import aiohttp
+import logging
+from typing import List, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+class OfqualAOSearchClient:
+    """Client for searching Ofqual awarding organisations by course or subject."""
+
+    BASE_URL = "https://api.ofqual.gov.uk/api/v1/awarding-organisations"
+
+    async def search(self, *, subject: Optional[str] = None, course: Optional[str] = None) -> List[Dict]:
+        """Return a list of awarding organisations matching the query."""
+        params = {}
+        if subject:
+            params["subject"] = subject
+        if course:
+            params["course"] = course
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(self.BASE_URL, params=params) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        # API may return list directly or under "results" key
+                        if isinstance(data, dict):
+                            return data.get("results", data.get("items", []))
+                        return data
+                    logger.error("Ofqual API error %s", resp.status)
+        except Exception as e:
+            logger.error("Ofqual API request failed: %s", e)
+        return []

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ A comprehensive Know Your Customer (KYC) verification system specifically design
 
 🎓 **Educational Provider Verification**
 - Ofqual qualification validation
+- Awarding organisation search via Ofqual API
 - Ofsted inspection ratings
 - ESFA funding status verification
 - UKPRN validation

--- a/templates/awarding_organisations.html
+++ b/templates/awarding_organisations.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}Select Awarding Organisation{% endblock %}
+{% block content %}
+<div class="max-w-3xl mx-auto">
+    <h2 class="text-2xl font-semibold text-gray-900 mb-4">Select Awarding Organisation</h2>
+    {% if organisations %}
+    <form method="get" action="/centre-submission">
+        <div class="space-y-4">
+            {% for org in organisations %}
+            <div class="border rounded-md p-3 flex items-center">
+                <input type="radio" name="ao_id" value="{{ org.id or org['id'] }}" class="mr-3" required>
+                <span>{{ org.name or org['name'] }}</span>
+            </div>
+            {% endfor %}
+        </div>
+        {% if subject %}<input type="hidden" name="subject" value="{{ subject }}">{% endif %}
+        {% if course %}<input type="hidden" name="course" value="{{ course }}">{% endif %}
+        <div class="mt-6 text-right">
+            <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded-md">Use Selected Organisation</button>
+        </div>
+    </form>
+    {% else %}
+    <p>No awarding organisations found for the given criteria.</p>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `OfqualAOSearchClient` for retrieving awarding organisations
- expose `/ofqual/awarding-organisations` endpoint
- template for selecting an awarding organisation
- document new feature in README

## Testing
- `python -m py_compile app/services/ofqual_awarding_orgs.py app/main.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6882a1c33b40832c9b8221fa151384cb