### PR TITLE
Add Ofqual register search

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -774,6 +774,27 @@ async def search_awarding_organisations(request: Request, subject: Optional[str]
         },
     )
 
+
+@app.get("/ofqual/search", response_class=HTMLResponse)
+async def ofqual_search(request: Request, course: Optional[str] = None, location: Optional[str] = None):
+    """Search the Ofqual Register for organisations and qualifications."""
+    client = OfqualAOSearchClient()
+    organisations = []
+    qualifications = []
+    if course or location:
+        organisations = await client.search(course=course, location=location)
+        qualifications = await client.search_qualifications(course=course, location=location)
+    return templates.TemplateResponse(
+        "ofqual_search.html",
+        {
+            "request": request,
+            "course": course,
+            "location": location,
+            "organisations": organisations,
+            "qualifications": qualifications,
+        },
+    )
+
 @app.get("/urn/validate/{urn}")
 async def validate_urn_endpoint(urn: str):
     """Quick URN validation endpoint using Ofsted search"""

--- a/app/services/ofqual_register.py
+++ b/app/services/ofqual_register.py
@@ -1,0 +1,39 @@
+import aiohttp
+import logging
+import os
+from typing import List, Dict
+
+logger = logging.getLogger(__name__)
+
+class OfqualRegisterClient:
+    """Client for searching Ofqual Register for organisations and qualifications."""
+
+    def __init__(self, base_url: str | None = None, api_key: str | None = None):
+        self.base_url = (base_url or os.getenv("APIMgmgt_URL", "https://api.ofqual.gov.uk")).rstrip("/")
+        self.api_key = api_key or os.getenv("APISubKey")
+
+    async def _request(self, path: str, params: Dict) -> List[Dict]:
+        headers = {}
+        if self.api_key:
+            headers["Ocp-Apim-Subscription-Key"] = self.api_key
+        url = f"{self.base_url}{path}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, params=params, headers=headers) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        if isinstance(data, dict):
+                            return data.get("items", data.get("results", []))
+                        return data
+                    logger.error("Ofqual API error %s for %s", resp.status, path)
+        except Exception as e:
+            logger.error("Ofqual API request failed for %s: %s", path, e)
+        return []
+
+    async def search_organisations(self, search: str, page: int = 1, limit: int = 25) -> List[Dict]:
+        """Search Ofqual organisations."""
+        return await self._request("/api/Organisations", {"search": search, "page": page, "limit": limit})
+
+    async def search_qualifications(self, search: str, page: int = 1, limit: int = 25) -> List[Dict]:
+        """Search Ofqual qualifications."""
+        return await self._request("/api/Qualifications", {"search": search, "page": page, "limit": limit})

--- a/readme.md
+++ b/readme.md
@@ -68,3 +68,28 @@ Alternatively you can call the FastAPI endpoint directly:
 ```
 GET /ofqual/awarding-organisations?subject=history&course=gcse
 ```
+
+### Example: Ofqual Register Search
+
+You can search both organisations and qualifications by course and location using `OfqualAOSearchClient`:
+
+```python
+import asyncio
+from app.services.ofqual_awarding_orgs import OfqualAOSearchClient
+
+
+async def demo():
+    client = OfqualAOSearchClient()
+    organisations = await client.search(course="maths", location="london")
+    qualifications = await client.search_qualifications(course="maths", location="london")
+    print("Organisations:", len(organisations))
+    print("Qualifications:", len(qualifications))
+
+asyncio.run(demo())
+```
+
+Or via the new endpoint:
+
+```
+GET /ofqual/search?course=maths&location=london
+```

--- a/templates/ofqual_search.html
+++ b/templates/ofqual_search.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+{% block title %}Ofqual Search{% endblock %}
+{% block content %}
+<div class="max-w-5xl mx-auto">
+    <h2 class="text-2xl font-semibold text-gray-900 mb-4">Search Ofqual Register</h2>
+    <form method="get" action="/ofqual/search" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="course">Course</label>
+            <input type="text" id="course" name="course" value="{{ course or '' }}" class="w-full border border-gray-300 rounded-md px-3 py-2" placeholder="e.g., Maths">
+        </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="location">Location</label>
+            <input type="text" id="location" name="location" value="{{ location or '' }}" class="w-full border border-gray-300 rounded-md px-3 py-2" placeholder="e.g., London">
+        </div>
+        <div class="flex items-end">
+            <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded-md">Search</button>
+        </div>
+    </form>
+
+    {% if organisations or qualifications %}
+    <div class="space-y-10">
+        {% if organisations %}
+        <form method="get" action="/centre-submission">
+            <input type="hidden" name="course" value="{{ course }}">
+            <input type="hidden" name="location" value="{{ location }}">
+            <h3 class="text-xl font-semibold mb-2">Organisations</h3>
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th></th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Recognition Number</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        {% for org in organisations %}
+                        <tr>
+                            <td class="px-4 py-2"><input type="radio" name="organisation_id" value="{{ org.recognitionNumber or org['recognitionNumber'] }}" required></td>
+                            <td class="px-4 py-2">{{ org.name or org['name'] }}</td>
+                            <td class="px-4 py-2">{{ org.recognitionNumber or org['recognitionNumber'] }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <div class="mt-4 text-right">
+                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md">Use Selected Organisation</button>
+            </div>
+        </form>
+        {% endif %}
+
+        {% if qualifications %}
+        <h3 class="text-xl font-semibold mb-2">Qualifications</h3>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Number</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    {% for qual in qualifications %}
+                    <tr>
+                        <td class="px-4 py-2">{{ qual.title or qual['title'] }}</td>
+                        <td class="px-4 py-2">{{ qual.qualificationNumber or qual['qualificationNumber'] }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+    </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend Ofqual client with search for organisations and qualifications
- add new endpoint `/ofqual/search` with form for course/location
- provide HTML template for selection of organisations/qualifications
- document new usage in `readme`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883329d5d20832c82b739137c92e0ae