### PR TITLE
Link Ofqual search to centre submission

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -168,10 +168,18 @@ async def onboard_form(request: Request):
 # Centre Submission workflow
 
 @app.get("/centre-submission", response_class=HTMLResponse)
-async def centre_submission_form(request: Request):
+async def centre_submission_form(
+    request: Request,
+    organisation_id: Optional[str] = None,
+    organisation_name: Optional[str] = None,
+):
     return templates.TemplateResponse(
         "centre_submission_form.html",
-        {"request": request}
+        {
+            "request": request,
+            "organisation_id": organisation_id,
+            "organisation_name": organisation_name,
+        },
     )
 
 

--- a/templates/centre_submission_form.html
+++ b/templates/centre_submission_form.html
@@ -18,6 +18,7 @@
         </div>
         <div class="border-b border-gray-200 pb-6">
             <h3 class="text-lg font-semibold text-gray-900 mb-4">Qualification Requested</h3>
+            <a href="/ofqual/search" class="text-sm text-blue-600 underline">Search Ofqual Register</a>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2" for="qualification_id">Qualification ID</label>
@@ -25,11 +26,11 @@
                 </div>
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2" for="ao_id">Awarding Org ID</label>
-                    <input type="text" id="ao_id" name="ao_id" required class="w-full border border-gray-300 rounded-md px-3 py-2">
+                    <input type="text" id="ao_id" name="ao_id" value="{{ organisation_id or '' }}" required class="w-full border border-gray-300 rounded-md px-3 py-2">
                 </div>
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2" for="ao_name">Awarding Org Name</label>
-                    <input type="text" id="ao_name" name="ao_name" required class="w-full border border-gray-300 rounded-md px-3 py-2">
+                    <input type="text" id="ao_name" name="ao_name" value="{{ organisation_name or '' }}" required class="w-full border border-gray-300 rounded-md px-3 py-2">
                 </div>
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2" for="title">Qualification Title</label>

--- a/templates/ofqual_search.html
+++ b/templates/ofqual_search.html
@@ -23,6 +23,7 @@
         <form method="get" action="/centre-submission">
             <input type="hidden" name="course" value="{{ course }}">
             <input type="hidden" name="location" value="{{ location }}">
+            <input type="hidden" name="organisation_name" id="organisation_name">
             <h3 class="text-xl font-semibold mb-2">Organisations</h3>
             <div class="overflow-x-auto">
                 <table class="min-w-full divide-y divide-gray-200">
@@ -36,7 +37,7 @@
                     <tbody class="bg-white divide-y divide-gray-200">
                         {% for org in organisations %}
                         <tr>
-                            <td class="px-4 py-2"><input type="radio" name="organisation_id" value="{{ org.recognitionNumber or org['recognitionNumber'] }}" required></td>
+                            <td class="px-4 py-2"><input type="radio" name="organisation_id" value="{{ org.recognitionNumber or org['recognitionNumber'] }}" data-org-name="{{ org.name or org['name'] }}" required></td>
                             <td class="px-4 py-2">{{ org.name or org['name'] }}</td>
                             <td class="px-4 py-2">{{ org.recognitionNumber or org['recognitionNumber'] }}</td>
                         </tr>
@@ -74,4 +75,13 @@
     </div>
     {% endif %}
 </div>
+<script>
+    const radios = document.querySelectorAll('input[name="organisation_id"]');
+    const nameInput = document.getElementById('organisation_name');
+    radios.forEach(r => {
+        r.addEventListener('change', () => {
+            nameInput.value = r.dataset.orgName;
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow `/centre-submission` to accept organisation details via query params
- prepopulate AO fields in `centre_submission_form.html`
- provide link to Ofqual search from the centre submission form
- add hidden field and script in `ofqual_search.html` to send back organisation name

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688378fb4e10832c87f15ed5f0470bfa