### PR TITLE
Handle empty provider dashboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -644,6 +644,15 @@ async def provider_status_page(verification_id: str, request: Request):
     )
 
 
+@app.get("/provider-dashboard", response_class=HTMLResponse)
+async def provider_dashboard_no_id(request: Request):
+    """Dashboard page when no verification ID is provided"""
+    return templates.TemplateResponse(
+        "provider_dashboard.html",
+        {"request": request, "provider": None},
+    )
+
+
 @app.get("/provider-dashboard/{verification_id}", response_class=HTMLResponse)
 async def provider_dashboard(verification_id: str, request: Request):
     """Dashboard view for a single provider application"""

--- a/templates/provider_dashboard.html
+++ b/templates/provider_dashboard.html
@@ -8,6 +8,7 @@
         <p class="text-gray-600 mt-2">Overview of your educational provider application</p>
     </div>
 
+    {% if provider %}
     <!-- Statistics Cards -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         <div class="bg-white rounded-lg shadow-md p-6">
@@ -95,5 +96,12 @@
             </tbody>
         </table>
     </div>
+    {% else %}
+    <div class="bg-white rounded-lg shadow-md p-8 text-center">
+        <h2 class="text-lg font-semibold text-gray-900 mb-2">No application selected</h2>
+        <p class="text-gray-600 mb-4">Start by submitting a new provider application.</p>
+        <a href="/onboard" class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Go to Onboarding</a>
+    </div>
+    {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a route for `/provider-dashboard` without an ID
- update provider dashboard template to support missing provider data

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6883894d30e0832c8284fa620bfe00ae