### PR TITLE
Add login and simple RBAC

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,11 @@
                     <a href="/documents" class="hover:text-blue-200">Documents</a>
                     <a href="/help" class="hover:text-blue-200">Help &amp; Support</a>
                     <a href="/profile" class="hover:text-blue-200">User Profile</a>
+                    {% if request.session.get('user') %}
+                    <a href="/logout" class="hover:text-blue-200">Logout</a>
+                    {% else %}
+                    <a href="/login" class="hover:text-blue-200">Login</a>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/templates/documents.html
+++ b/templates/documents.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block title %}Documents{% endblock %}
 {% block content %}
+{% if user %}
+<p class="text-sm text-gray-600 mb-2">Logged in as {{ user.name }} ({{ user.role.replace('_',' ')|title }})</p>
+{% endif %}
 <h1 class="text-2xl font-bold mb-4">Document Repository</h1>
 <p>Upload and manage documents for reuse across applications.</p>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Login</h1>
+{% if error %}
+<p class="text-red-600 mb-4">{{ error }}</p>
+{% endif %}
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block font-medium">Username</label>
+    <input type="text" name="username" class="border rounded w-full px-3 py-2">
+  </div>
+  <div>
+    <label class="block font-medium">Password</label>
+    <input type="password" name="password" class="border rounded w-full px-3 py-2">
+  </div>
+  <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Login</button>
+</form>
+<p class="mt-4 text-gray-500">Demo accounts:</p>
+<ul class="list-disc ml-5 text-gray-600">
+  <li>centre1 / centrepass (Learning Centre)</li>
+  <li>awarding1 / awardingpass (Awarding Organisation)</li>
+</ul>
+{% endblock %}

--- a/templates/messages.html
+++ b/templates/messages.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block title %}Messages{% endblock %}
 {% block content %}
+{% if user %}
+<p class="text-sm text-gray-600 mb-2">Logged in as {{ user.name }} ({{ user.role.replace('_',' ')|title }})</p>
+{% endif %}
 <h1 class="text-2xl font-bold mb-4">Messages</h1>
 <p>Your in-app messages will appear here.</p>
 {% endblock %}

--- a/templates/my_organisation.html
+++ b/templates/my_organisation.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block title %}My Organisation{% endblock %}
 {% block content %}
+{% if user %}
+<p class="text-sm text-gray-600 mb-2">Logged in as {{ user.name }} ({{ user.role.replace('_',' ')|title }})</p>
+{% endif %}
 <h1 class="text-2xl font-bold mb-4">My Organisation</h1>
 <p>This section will allow you to manage organisational details and delivery sites.</p>
 {% endblock %}

--- a/templates/provider_dashboard.html
+++ b/templates/provider_dashboard.html
@@ -2,6 +2,9 @@
 {% block title %}Application Dashboard{% endblock %}
 {% block content %}
 <div class="max-w-7xl mx-auto">
+    {% if user %}
+    <p class="text-sm text-gray-600 mb-4">Logged in as {{ user.name }} ({{ user.role.replace('_',' ')|title }})</p>
+    {% endif %}
     <!-- Header -->
     <div class="mb-8">
         <h1 class="text-3xl font-bold text-gray-900">Qualification Applications Dashboard</h1>


### PR DESCRIPTION
## Summary
- include session middleware, demo users and helpers
- add login/logout endpoints
- restrict applications routes to awarding organisations
- show logged in role on content pages
- add login page and navigation links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885f00c6b48832ca810b0829c9a3f36