### PR TITLE
Update README with MCP wrapper usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,3 +105,22 @@ Or via the new endpoint:
 ```
 GET /ofqual/search?course=maths&location=london
 ```
+
+## MCP Wrapper Usage
+
+The application exposes a lightweight wrapper that speaks the
+**Model Context Protocol (MCP)**. This wrapper lets downstream AI agents
+retrieve context from the service in a standardised document format.
+
+```python
+from app.mcp_wrapper import KYCContextSource
+
+source = KYCContextSource(base_url="https://your-kyc-service.com")
+health_doc = await source.health()
+print(health_doc.content)
+```
+
+Each method on `KYCContextSource` returns an `MCPDocument` which contains the
+raw content, metadata about when it was retrieved, and the originating URL.
+You can use this wrapper to fetch awarding organisation data or verification
+statuses without dealing with HTTP directly.


### PR DESCRIPTION
## Summary
- document Model Context Protocol wrapper usage in README

## Testing
- `flake8` *(fails: E501, W293, etc)*

------
https://chatgpt.com/codex/tasks/task_e_68872aa6fb90832cb3fe512c4a532de2