### PR TITLE
Add MCP wrapper endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,19 @@ async def demo():
 asyncio.run(demo())
 ```
 
+### MCP Wrapper Endpoint
+
+Once the server is running you can also access the wrapper via HTTP.
+Calling `/mcp/health` returns the underlying `/health` response wrapped in the MCP metadata:
+
+```bash
+curl http://localhost:8000/mcp/health
+```
+
+The JSON payload contains the raw content and context information returned by
+`KYCContextSource`.
+
+
 Alternatively you can call the FastAPI endpoint directly:
 
 ```


### PR DESCRIPTION
## Summary
- instantiate KYCContextSource at app startup
- expose `/mcp/health` endpoint that returns MCP metadata
- document how to call the new endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68873ef010fc832caf7f1da5b7de3ccd