### PR TITLE
Fix MCP wrapper base URL handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from contextlib import asynccontextmanager
 import os
 from typing import Dict, List, Optional
@@ -16,6 +16,8 @@ import asyncio
 import uuid
 import aiohttp
 import requests
+
+from app.mcp_wrapper import KYCContextSource
 
 # Ofqual awarding organisation search
 from app.services.ofqual_awarding_orgs import OfqualAOSearchClient
@@ -47,6 +49,9 @@ from app.centre_submission import (
 providers_db = []
 centre_submissions: List[CentreSubmission] = []
 processing_queue = {}
+
+# MCP wrapper instance (created during startup)
+mcp_wrapper: KYCContextSource | None = None
 
 # Demo users for login
 users = {
@@ -99,6 +104,10 @@ def map_provider_type(provider_type_str: str) -> ProviderType:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     print("Starting Educational KYC application with Orchestrator")
+
+    global mcp_wrapper
+    default_base = f"http://localhost:{os.getenv('PORT', '8000')}"
+    mcp_wrapper = KYCContextSource(base_url=os.getenv("MCP_BASE_URL", default_base))
 
     # Check API configuration
     api_status = check_api_configuration()
@@ -1198,6 +1207,26 @@ async def health_check():
         "api_configurations": api_status,
         "orchestrator_available": True,
         "timestamp": datetime.now().isoformat(),
+    }
+
+
+@app.get("/mcp/health")
+async def mcp_health():
+    """Proxy health check using the MCP wrapper."""
+    if not mcp_wrapper:
+        return JSONResponse(status_code=503, content={"error": "MCP wrapper not initialised"})
+
+    try:
+        doc = await mcp_wrapper.health()
+    except Exception as exc:  # noqa: BLE001
+        return JSONResponse(status_code=502, content={"error": str(exc)})
+
+    return {
+        "content": doc.content,
+        "source_url": doc.source_url,
+        "media_type": doc.media_type,
+        "retrieved_at": doc.retrieved_at.isoformat(),
+        "context": doc.context,
     }
 
 

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,19 @@ async def demo():
 asyncio.run(demo())
 ```
 
+### MCP Wrapper Endpoint
+
+Once the server is running you can access the wrapper via HTTP. If deploying on Railway make sure the `MCP_BASE_URL` environment variable matches your service URL; otherwise the wrapper defaults to `http://localhost:$PORT`.
+Calling `/mcp/health` returns the underlying `/health` response wrapped in the MCP metadata:
+
+```bash
+curl http://localhost:$PORT/mcp/health
+```
+
+The JSON payload contains the raw content and context information returned by
+`KYCContextSource`.
+
+
 Alternatively you can call the FastAPI endpoint directly:
 
 ```
@@ -115,11 +128,13 @@ containing the raw response and metadata.
 
 ```python
 import asyncio
+import os
 from app.mcp_wrapper import KYCContextSource
 
 
 async def demo():
-    source = KYCContextSource(base_url="http://localhost:8000")
+    default_base = f"http://localhost:{os.getenv('PORT', '8000')}"
+    source = KYCContextSource(base_url=os.getenv("MCP_BASE_URL", default_base))
     health = await source.health()
     print("Health status:", health.content)
 


### PR DESCRIPTION
## Summary
- use PORT environment variable to construct MCP wrapper base URL
- handle connection errors when calling the wrapper
- document MCP_BASE_URL usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68873ef010fc832caf7f1da5b7de3ccd