### PR TITLE
Add credential verification feature

### DIFF
--- a/app/vc_verify.py
+++ b/app/vc_verify.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Any, Optional
+
+# Simple trusted issuer and revocation data for demo purposes
+TRUSTED_ISSUERS = {"https://certify3.io/kyc"}
+AUTHORIZED_KEYS = {"https://certify3.io/kyc": {"https://certify3.io/keys/1"}}
+TRUST_REGISTRY = {"https://certify3.io/kyc": {"EducationalProvider"}}
+REVOKED_IDS = set()
+
+
+def verify_credential(credential: Dict[str, Any], expected_subject: Optional[str] = None) -> Dict[str, Any]:
+    """Validate a Verifiable Credential issued by this service."""
+    issuer = credential.get("issuer")
+    issuer_trusted = issuer in TRUSTED_ISSUERS
+
+    proof = credential.get("proof", {})
+    key_valid = issuer_trusted and proof.get("verificationMethod") in AUTHORIZED_KEYS.get(issuer, set())
+
+    types = set(credential.get("type", []))
+    trust_registry_ok = issuer_trusted and "EducationalProvider" in types and "EducationalProvider" in TRUST_REGISTRY.get(issuer, set())
+
+    expiration = credential.get("expirationDate")
+    not_expired = True
+    if expiration:
+        try:
+            not_expired = datetime.fromisoformat(expiration.rstrip("Z")) > datetime.utcnow()
+        except Exception:
+            not_expired = False
+
+    cred_id = credential.get("id") or credential.get("credentialSubject", {}).get("id")
+    not_revoked = cred_id not in REVOKED_IDS
+
+    subject_match = True
+    if expected_subject:
+        subject_match = credential.get("credentialSubject", {}).get("id") == expected_subject
+
+    is_valid = all([issuer_trusted, key_valid, trust_registry_ok, not_expired, not_revoked, subject_match])
+
+    return {
+        "issuer_trusted": issuer_trusted,
+        "key_valid": key_valid,
+        "trust_registry_ok": trust_registry_ok,
+        "not_expired": not_expired,
+        "not_revoked": not_revoked,
+        "subject_match": subject_match,
+        "is_valid": is_valid,
+    }
+
+
+__all__ = ["verify_credential"]

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
                     <a href="/my-organisation" class="hover:text-blue-200">My Organisation</a>
                     <a href="/messages" class="hover:text-blue-200">Messages</a>
                     <a href="/documents" class="hover:text-blue-200">Documents</a>
+                    <a href="/verify-credential" class="hover:text-blue-200">Verify Credential</a>
                     <a href="/help" class="hover:text-blue-200">Help &amp; Support</a>
                     <a href="/profile" class="hover:text-blue-200">User Profile</a>
                     {% if request.session.get('user') %}

--- a/templates/verify_credential.html
+++ b/templates/verify_credential.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Verify Credential{% endblock %}
+{% block content %}
+<div class="max-w-3xl mx-auto">
+    <h2 class="text-2xl font-bold text-gray-900 mb-4">Verify Credential</h2>
+    <form method="POST" action="/verify-credential" class="bg-white rounded-lg shadow-md p-6 space-y-4">
+        <div>
+            <label for="credential_json" class="block text-sm font-medium text-gray-700 mb-1">Credential JSON</label>
+            <textarea id="credential_json" name="credential_json" rows="8" required class="w-full border border-gray-300 rounded-md p-2">{{ credential_json or '' }}</textarea>
+        </div>
+        <div>
+            <label for="expected_subject" class="block text-sm font-medium text-gray-700 mb-1">Expected Subject ID (optional)</label>
+            <input type="text" id="expected_subject" name="expected_subject" value="{{ expected_subject or '' }}" class="w-full border border-gray-300 rounded-md p-2" placeholder="urn:uuid:...">
+        </div>
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-md">Verify</button>
+    </form>
+
+    {% if error %}
+    <div class="mt-4 text-red-600">{{ error }}</div>
+    {% endif %}
+
+    {% if result %}
+    <div class="mt-6 bg-gray-50 p-4 rounded-lg">
+        <h3 class="text-lg font-semibold text-gray-800 mb-2">Verification Result</h3>
+        <ul class="space-y-1 text-sm text-gray-700">
+            <li>Issuer trusted: {{ '✓' if result.issuer_trusted else '✗' }}</li>
+            <li>Key valid: {{ '✓' if result.key_valid else '✗' }}</li>
+            <li>Trust registry: {{ '✓' if result.trust_registry_ok else '✗' }}</li>
+            <li>Not expired: {{ '✓' if result.not_expired else '✗' }}</li>
+            <li>Not revoked: {{ '✓' if result.not_revoked else '✗' }}</li>
+            <li>Subject matches: {{ '✓' if result.subject_match else '✗' }}</li>
+        </ul>
+        <p class="mt-2 font-bold">Overall: {{ 'Valid' if result.is_valid else 'Invalid' }}</p>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_vc_verify.py
+++ b/tests/test_vc_verify.py
@@ -1,0 +1,16 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.vc_issue import create_verifiable_credential
+from app.vc_verify import verify_credential
+
+
+def test_verify_valid_credential():
+    provider = {
+        "id": 1,
+        "verification_id": "11111111-1111-1111-1111-111111111111",
+        "organisation_name": "Test Provider",
+        "status": "approved",
+    }
+
+    vc = create_verifiable_credential(provider)
+    result = verify_credential(vc, expected_subject=vc["credentialSubject"]["id"])
+    assert result["is_valid"]


### PR DESCRIPTION
## Summary
- add VC validation logic in `app/vc_verify.py`
- create `/verify-credential` page and routes
- expose "Verify Credential" in navigation
- tests for credential verification

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b6f3c304832c9df6642dd014521c