### PR TITLE
Add QR code verification for credentials

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse
 from contextlib import asynccontextmanager
 import os
+import base64
 from typing import Dict, List, Optional
 from datetime import datetime
 import json
@@ -37,6 +38,7 @@ from app.services.education_kyc_orchestrator import (
 )
 from app.vc_issue import create_verifiable_credential
 from app.vc_verify import verify_credential
+from app.qr_utils import generate_qr_code
 from app.centre_submission import (
     CentreSubmission,
     ParentOrganisation,
@@ -878,10 +880,19 @@ async def verifiable_credential_page(verification_id: str, request: Request):
         )
 
     credential = create_verifiable_credential(provider)
+    credential_json = json.dumps(credential)
+    encoded = base64.urlsafe_b64encode(credential_json.encode()).decode()
+    verify_url = request.url_for("verify_via_link") + f"?credential={encoded}"
+    qr_data = generate_qr_code(verify_url)
 
     return templates.TemplateResponse(
         "credential.html",
-        {"request": request, "credential": credential, "provider": provider},
+        {
+            "request": request,
+            "credential": credential,
+            "provider": provider,
+            "qr_data": qr_data,
+        },
     )
 
 
@@ -924,6 +935,36 @@ async def verify_credential_submit(
             "result": result,
             "credential_json": credential_json,
             "expected_subject": expected_subject,
+            "error": None,
+        },
+    )
+
+
+@app.get("/verify", response_class=HTMLResponse)
+async def verify_via_link(request: Request, credential: str):
+    """Verify a credential encoded in a URL parameter."""
+    try:
+        credential_json = base64.urlsafe_b64decode(credential.encode()).decode()
+        cred = json.loads(credential_json)
+    except Exception:
+        return templates.TemplateResponse(
+            "verify_credential.html",
+            {
+                "request": request,
+                "error": "Invalid credential data",
+                "result": None,
+            },
+        )
+
+    result = verify_credential(cred)
+
+    return templates.TemplateResponse(
+        "verify_credential.html",
+        {
+            "request": request,
+            "result": result,
+            "credential_json": credential_json,
+            "expected_subject": None,
             "error": None,
         },
     )

--- a/app/qr_utils.py
+++ b/app/qr_utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import base64
+import io
+from typing import Any
+
+import qrcode
+
+
+def generate_qr_code(data: str) -> str:
+    """Return base64-encoded PNG representing a QR code for the given data."""
+    qr = qrcode.QRCode(box_size=4, border=1)
+    qr.add_data(data)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+__all__ = ["generate_qr_code"]

--- a/readme.md
+++ b/readme.md
@@ -216,5 +216,10 @@ The returned JSON document includes a `proof` object with an Ed25519 signature. 
 * **Verification** – Third parties can validate a credential using standard VC libraries (e.g. [`jsonld-signatures`](https://github.com/digitalbazaar/jsonld-signatures`) or Hyperledger Aries). Verification consists of checking the `proof` signature, confirming the issuer URL, and validating the `credentialSubject` details.
 
 A successfully verified credential can be relied upon as proof that the organisation has completed the KYC process.
-main
+
+### QR Code Verification
+
+Each issued credential page now displays a QR code. Scanning the code opens the
+`/verify` endpoint with the credential embedded in the URL. The page
+automatically validates the credential and shows whether it is valid or not.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ python-dateutil==2.8.2
 beautifulsoup4==4.12.2
 lxml==4.9.3
 structlog==23.3.0
+qrcode==7.4.2

--- a/templates/credential.html
+++ b/templates/credential.html
@@ -6,6 +6,11 @@
         <h2 class="text-3xl font-bold text-gray-900">Verifiable Credential</h2>
         <p class="text-gray-600">Credential issued for {{ provider.organisation_name }}</p>
     </div>
-    <pre class="bg-gray-100 p-4 rounded-lg text-sm overflow-auto">{{ credential | tojson(indent=2) }}</pre>
+    <div class="flex flex-col md:flex-row gap-6">
+        <pre class="bg-gray-100 p-4 rounded-lg text-sm overflow-auto md:w-1/2">{{ credential | tojson(indent=2) }}</pre>
+        <div class="md:w-1/2 flex items-center justify-center">
+            <img src="data:image/png;base64,{{ qr_data }}" alt="Credential QR Code" class="border" />
+        </div>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- embed a QR code on the credential page
- provide endpoint `/verify` that decodes credentials from URL
- generate QR codes with a helper function
- document the new verification flow in the README
- add `qrcode` to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68889db72de8832cbc4bb12387941e85