### PR TITLE
Add credential revocation

### DIFF
--- a/app/vc_issue.py
+++ b/app/vc_issue.py
@@ -36,6 +36,13 @@ def create_verifiable_credential(provider: Dict[str, Any]) -> Dict[str, Any]:
         ),
     }
 
+    if provider.get("revoked") and provider.get("revocation_reason"):
+        credential["credentialStatus"] = {
+            "id": f"https://certify3.io/revocations/{subject_id}",
+            "type": "RevocationList2020Status",
+            "revocationReason": provider["revocation_reason"],
+        }
+
     return credential
 
 

--- a/app/vc_verify.py
+++ b/app/vc_verify.py
@@ -30,7 +30,13 @@ def verify_credential(credential: Dict[str, Any], expected_subject: Optional[str
             not_expired = False
 
     cred_id = credential.get("id") or credential.get("credentialSubject", {}).get("id")
-    not_revoked = cred_id not in REVOKED_IDS
+
+    status = credential.get("credentialStatus", {})
+    revoked_in_credential = bool(status.get("revocationReason"))
+    if revoked_in_credential:
+        REVOKED_IDS.add(cred_id)
+
+    not_revoked = cred_id not in REVOKED_IDS and not revoked_in_credential
 
     subject_match = True
     if expected_subject:

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -266,6 +266,19 @@
                                 Credential
                             </a>
                             {% endif %}
+
+                            {% if provider.revoked %}
+                            <span class="text-red-600 inline-flex items-center">Revoked</span>
+                            {% elif provider.status == 'approved' %}
+                            <form method="post" action="/revoke/{{ provider.verification_id }}" style="display:inline">
+                                <button type="submit" class="text-red-600 hover:text-red-900 inline-flex items-center">
+                                    <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                    </svg>
+                                    Revoke
+                                </button>
+                            </form>
+                            {% endif %}
                             
                             {% if provider.status == 'processing' %}
                             <span class="text-gray-400 inline-flex items-center">

--- a/tests/test_vc_verify.py
+++ b/tests/test_vc_verify.py
@@ -14,3 +14,19 @@ def test_verify_valid_credential():
     vc = create_verifiable_credential(provider)
     result = verify_credential(vc, expected_subject=vc["credentialSubject"]["id"])
     assert result["is_valid"]
+
+
+def test_verify_revoked_credential_fails():
+    provider = {
+        "id": 1,
+        "verification_id": "11111111-1111-1111-1111-111111111111",
+        "organisation_name": "Test Provider",
+        "status": "approved",
+        "revoked": True,
+        "revocation_reason": "Poor Credit",
+    }
+
+    vc = create_verifiable_credential(provider)
+    result = verify_credential(vc, expected_subject=vc["credentialSubject"]["id"])
+    assert not result["is_valid"]
+    assert not result["not_revoked"]


### PR DESCRIPTION
## Summary
- add endpoint to revoke issued credentials
- show revoke button in dashboard and display revoked status
- record revocation in credential when issued
- make verifier fail revoked credentials
- test revoked credential verification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b5c7ebd18832caa80faec6b2c4077