### PR TITLE
Handle revoked verification IDs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -890,6 +890,8 @@ async def get_verification_status(verification_id: str):
         "verification_id": verification_id,
         "status": provider["status"],
         "processing_status": processing_status,
+        "revoked": provider.get("revoked", False),
+        "revocation_reason": provider.get("revocation_reason"),
         "risk_level": provider.get("risk_level"),
         "organisation_name": provider["organisation_name"],
         "provider_type": provider.get("provider_type"),

--- a/templates/centre_submission_form.html
+++ b/templates/centre_submission_form.html
@@ -131,9 +131,16 @@ verificationInput.addEventListener('input', function(e) {
             const resp = await fetch(`/verification/${encodeURIComponent(value)}`);
             const data = await resp.json();
             if (!data.error) {
-                statusEl.classList.add('text-green-600');
-                statusEl.textContent = 'Verification ID confirmed';
-                disableOthers(false);
+                if (data.revoked) {
+                    statusEl.classList.add('text-red-600');
+                    const reason = data.revocation_reason ? `: ${data.revocation_reason}` : '';
+                    statusEl.textContent = `Verification ID revoked${reason}`;
+                    disableOthers(true);
+                } else {
+                    statusEl.classList.add('text-green-600');
+                    statusEl.textContent = 'Verification ID confirmed';
+                    disableOthers(false);
+                }
             } else {
                 statusEl.classList.add('text-red-600');
                 statusEl.textContent = 'Invalid Verification ID';


### PR DESCRIPTION
## Summary
- return revocation info from `/verification/{id}` endpoint
- show revoked message when validating IDs in centre submission form

## Testing
- `pytest tests/test_vc_verify.py -q`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688b620c69a4832cbba0b38330a4ab1a