### PR TITLE
Generate credential PDF download

### DIFF
--- a/app/pdf_utils.py
+++ b/app/pdf_utils.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import base64
+import io
+import json
+from typing import Any, Dict
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.units import mm
+from reportlab.lib.utils import ImageReader
+from reportlab.pdfgen import canvas
+
+
+def generate_credential_pdf(credential: Dict[str, Any], qr_b64: str) -> bytes:
+    """Return PDF bytes containing credential details and a QR code."""
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf, pagesize=A4)
+    width, height = A4
+
+    subject = credential.get("credentialSubject", {})
+    subject_name = subject.get("name", "")
+    issuer = credential.get("issuer", "")
+    issuance_date = credential.get("issuanceDate", "")
+
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(20 * mm, height - 30 * mm, f"Credential for: {subject_name}")
+    c.setFont("Helvetica", 12)
+    c.drawString(20 * mm, height - 40 * mm, f"Issuer: {issuer}")
+    c.drawString(20 * mm, height - 50 * mm, f"Issued: {issuance_date}")
+
+    # QR code
+    try:
+        qr_bytes = base64.b64decode(qr_b64)
+        qr_img = ImageReader(io.BytesIO(qr_bytes))
+        c.drawImage(qr_img, width - 60 * mm, height - 70 * mm, 40 * mm, 40 * mm)
+    except Exception:
+        pass
+
+    c.setFont("Courier", 8)
+    text_obj = c.beginText(20 * mm, height - 80 * mm)
+    for line in json.dumps(credential, indent=2).splitlines():
+        text_obj.textLine(line)
+    c.drawText(text_obj)
+
+    c.showPage()
+    c.save()
+    return buf.getvalue()
+
+
+__all__ = ["generate_credential_pdf"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ structlog==23.3.0
 qrcode==7.4.2
 SQLAlchemy==2.0.23
 psycopg2-binary==2.9.9
+httpx==0.26.0
+reportlab==4.0.5

--- a/templates/credential.html
+++ b/templates/credential.html
@@ -12,5 +12,11 @@
             <img src="data:image/png;base64,{{ qr_data }}" alt="Credential QR Code" class="border" />
         </div>
     </div>
+    <div class="mt-6">
+        <a href="{{ url_for('download_credential_pdf', verification_id=provider.verification_id) }}"
+           class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition">
+            Download PDF
+        </a>
+    </div>
 </div>
 {% endblock %}

--- a/tests/test_pdf_route.py
+++ b/tests/test_pdf_route.py
@@ -1,0 +1,22 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+from app.main import app, providers_db
+
+client = TestClient(app)
+
+
+def test_credential_pdf_download():
+    provider = {
+        "id": 99,
+        "verification_id": "test-pdf",
+        "organisation_name": "PDF Provider",
+        "status": "approved",
+    }
+    providers_db.append(provider)
+    resp = client.get("/credential/test-pdf/download")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/pdf")
+    assert "attachment" in resp.headers.get("content-disposition", "")
+    providers_db.remove(provider)


### PR DESCRIPTION
## Summary
- add `generate_credential_pdf` utility based on ReportLab
- support PDF downloads for credentials via new `/credential/{id}/download` route
- show download button on credential page
- include httpx and reportlab dependencies
- test PDF route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c59641ed8832c81cf7b1b48fdb935