### PR TITLE
Add onboarding method to MCP wrapper

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ A comprehensive Know Your Customer (KYC) verification system specifically design
 - UKPRN validation
 - Companies House integration
 - Model Context Protocol (MCP) wrapper for AI integrations
+- REST onboarding API with MCP wrapper support
 
 📊 **Risk Assessment**
 - Automated risk scoring
@@ -157,8 +158,20 @@ async def demo():
     orgs = await source.search_awarding_orgs(subject="maths")
     print(orgs.content)
 
+    onboarding = await source.onboard_provider(
+        {
+            "organisation_name": "Demo School",
+            "urn": "123456",
+            "postcode": "AB1 2CD",
+        }
+    )
+    print(onboarding.content)
+
 asyncio.run(demo())
 ```
+
+`onboard_provider` posts the given details to `/api/onboard` and returns the
+wrapped response, allowing automated client integrations.
 
 ## REST API Onboarding
 


### PR DESCRIPTION
## Summary
- extend `KYCContextSource` with a generic POST helper
- add `onboard_provider` method to call `/api/onboard`
- document new method in README with usage example
- mention REST onboarding API in feature list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688caa2853a4832cb686b7dabbd78563