### PR TITLE
Add table layout for documents page with action icons

### DIFF
--- a/templates/documents.html
+++ b/templates/documents.html
@@ -20,17 +20,81 @@
     <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Upload</button>
 </form>
 
-{% if documents %}
 <h2 class="text-xl font-semibold mt-8 mb-2">Your Documents</h2>
-<ul class="list-disc ml-6">
-{% for doc in documents %}
-    <li>
-        <a href="/static/uploads/{{ doc.stored_name }}" class="text-blue-600 hover:underline">{{ doc.name }}</a>
-        <span class="text-gray-500 text-sm">uploaded {{ doc.uploaded_at }}</span>
-    </li>
-{% endfor %}
-</ul>
-{% endif %}
+<div class="overflow-x-auto">
+    <table class="min-w-full bg-white divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Doc ID</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Format</th>
+                <th class="px-4 py-2"></th>
+                <th class="px-4 py-2"></th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+            {% for doc in documents %}
+            <tr>
+                <td class="px-4 py-2 text-sm text-gray-900">{{ loop.index }}</td>
+                <td class="px-4 py-2 text-sm"><a href="/static/uploads/{{ doc.stored_name }}" class="text-blue-600 hover:underline">{{ doc.name }}</a></td>
+                <td class="px-4 py-2 text-sm text-gray-500">{{ doc.name.split('.')[-1].upper() }}</td>
+                <td class="px-4 py-2 text-center">
+                    <a href="#" title="Attach to application" class="text-indigo-600 hover:text-indigo-900">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.364 6.364a4 4 0 105.656 5.656l6.364-6.364a4 4 0 00-5.656-5.656L9 10.828" />
+                        </svg>
+                    </a>
+                </td>
+                <td class="px-4 py-2 text-center">
+                    <a href="#" title="Share by email" class="text-indigo-600 hover:text-indigo-900">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                        </svg>
+                    </a>
+                </td>
+            </tr>
+            {% endfor %}
+            <tr>
+                <td class="px-4 py-2 text-sm text-gray-900">DOC001</td>
+                <td class="px-4 py-2 text-sm text-blue-600 hover:underline">Centre Policy</td>
+                <td class="px-4 py-2 text-sm text-gray-500">PDF</td>
+                <td class="px-4 py-2 text-center">
+                    <a href="#" title="Attach to application" class="text-indigo-600 hover:text-indigo-900">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.364 6.364a4 4 0 105.656 5.656l6.364-6.364a4 4 0 00-5.656-5.656L9 10.828" />
+                        </svg>
+                    </a>
+                </td>
+                <td class="px-4 py-2 text-center">
+                    <a href="#" title="Share by email" class="text-indigo-600 hover:text-indigo-900">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                        </svg>
+                    </a>
+                </td>
+            </tr>
+            <tr>
+                <td class="px-4 py-2 text-sm text-gray-900">DOC002</td>
+                <td class="px-4 py-2 text-sm text-blue-600 hover:underline">Staff List</td>
+                <td class="px-4 py-2 text-sm text-gray-500">XLSX</td>
+                <td class="px-4 py-2 text-center">
+                    <a href="#" title="Attach to application" class="text-indigo-600 hover:text-indigo-900">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.364 6.364a4 4 0 105.656 5.656l6.364-6.364a4 4 0 00-5.656-5.656L9 10.828" />
+                        </svg>
+                    </a>
+                </td>
+                <td class="px-4 py-2 text-center">
+                    <a href="#" title="Share by email" class="text-indigo-600 hover:text-indigo-900">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                        </svg>
+                    </a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 <div id="uploadResult" class="mt-4 text-sm"></div>
 


### PR DESCRIPTION
## Summary
- show documents in a table with Doc ID, Name and Format columns
- add icons to attach a document to applications or share by email
- include two sample document rows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dc85aa660832ca01593c061bf6a4b