### PR TITLE
Filter Ofqual search for Pearson qualifications

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1433,7 +1433,9 @@ async def ofqual_search(
     qualifications: List[Dict] = []
 
     if Title:
-        organisations = await client.search(course=Title)
+        # Always look up the Pearson Education awarding organisation and
+        # restrict qualifications to those available to learners
+        organisations = await client.search()
         qualifications = await client.search_qualifications(course=Title)
 
     return templates.TemplateResponse(

--- a/app/services/ofqual_awarding_orgs.py
+++ b/app/services/ofqual_awarding_orgs.py
@@ -22,8 +22,8 @@ class OfqualAOSearchClient:
         limit: int = 50,
     ) -> List[Dict]:
         """Return a list of awarding organisations matching the query."""
-        #search_terms = " ".join(filter(None, [subject or course, location]))
-        search_terms = "Pearson"
+        # Only search for the Pearson Education awarding organisation
+        search_terms = "Pearson Education"
         params = {"search": search_terms, "page": page, "limit": limit}
 
         headers = {}
@@ -53,7 +53,13 @@ class OfqualAOSearchClient:
     ) -> List[Dict]:
         """Return a list of qualifications matching the query."""
         search_terms = " ".join(filter(None, [course, location]))
-        params = {"search": search_terms, "page": page, "limit": limit}
+        params = {
+            "search": search_terms,
+            "page": page,
+            "limit": limit,
+            "awardingOrganisations": "Pearson Education",
+            "availability": "Available to learners",
+        }
 
         headers = {}
         if self.api_key:

--- a/templates/ofqual_search.html
+++ b/templates/ofqual_search.html
@@ -69,7 +69,7 @@
             <input type="hidden" name="organisation_name" id="organisation_name">
             <h3 class="text-xl font-semibold mb-2">Organisations</h3>
             <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200">
+                <table class="min-w-full divide-y divide-gray-200 bg-white shadow rounded-lg overflow-hidden">
                     <thead class="bg-gray-50">
                         <tr>
                             <th></th>
@@ -77,9 +77,9 @@
                             <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Recognition Number</th>
                         </tr>
                     </thead>
-                    <tbody class="bg-white divide-y divide-gray-200">
+                    <tbody class="divide-y divide-gray-200">
                         {% for org in organisations %}
-                        <tr>
+                        <tr class="hover:bg-gray-50">
                             <td class="px-4 py-2"><input type="radio" name="organisation_id" value="{{ org.recognitionNumber or org['recognitionNumber'] }}" data-org-name="{{ org.name or org['name'] }}" required></td>
                             <td class="px-4 py-2">{{ org.name or org['name'] }}</td>
                             <td class="px-4 py-2">{{ org.recognitionNumber or org['recognitionNumber'] }}</td>
@@ -97,18 +97,20 @@
         {% if qualifications %}
         <h3 class="text-xl font-semibold mb-2">Qualifications</h3>
         <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
+            <table class="min-w-full divide-y divide-gray-200 bg-white shadow rounded-lg overflow-hidden">
                 <thead class="bg-gray-50">
                     <tr>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Number</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Availability</th>
                     </tr>
                 </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
+                <tbody class="divide-y divide-gray-200">
                     {% for qual in qualifications %}
-                    <tr>
+                    <tr class="hover:bg-gray-50">
                         <td class="px-4 py-2">{{ qual.title or qual['title'] }}</td>
                         <td class="px-4 py-2">{{ qual.qualificationNumber or qual['qualificationNumber'] }}</td>
+                        <td class="px-4 py-2">{{ qual.availability or qual['availability'] }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/tests/test_ofqual_awarding_orgs.py
+++ b/tests/test_ofqual_awarding_orgs.py
@@ -1,0 +1,52 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+from app.services.ofqual_awarding_orgs import OfqualAOSearchClient
+
+
+def test_search_qualifications_filters_awarding_org_and_availability():
+    client = OfqualAOSearchClient()
+
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    response = AsyncMock()
+    response.status = 200
+    response.__aenter__.return_value = response
+    response.json = AsyncMock(return_value={"results": []})
+    session.get = Mock(return_value=response)
+
+    with patch("aiohttp.ClientSession", return_value=session):
+        asyncio.run(client.search_qualifications(course="maths"))
+        session.get.assert_called_with(
+            f"{client.base_url}/api/Qualifications",
+            params={
+                "search": "maths",
+                "page": 1,
+                "limit": 25,
+                "awardingOrganisations": "Pearson Education",
+                "availability": "Available to learners",
+            },
+            headers={},
+        )
+
+
+def test_search_uses_pearson_education():
+    client = OfqualAOSearchClient()
+
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    response = AsyncMock()
+    response.status = 200
+    response.__aenter__.return_value = response
+    response.json = AsyncMock(return_value={"results": []})
+    session.get = Mock(return_value=response)
+
+    with patch("aiohttp.ClientSession", return_value=session):
+        asyncio.run(client.search())
+        session.get.assert_called_with(
+            f"{client.base_url}/api/Organisations",
+            params={"search": "Pearson Education", "page": 1, "limit": 50},
+            headers={},
+        )


### PR DESCRIPTION
## Summary
- limit Ofqual API requests to Pearson Education qualifications available to learners
- modernize organisation and qualification result tables
- cover new filters with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dcd5f6704832c8bfa2a3e00e563f4