### PR TITLE
Fix Ofqual qualification search

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1429,13 +1429,10 @@ async def ofqual_search(
     The remaining filter parameters are accepted for future use.
     """
     client = OfqualAOSearchClient()
-    organisations: List[Dict] = []
     qualifications: List[Dict] = []
 
     if Title:
-        # Always look up the Pearson Education awarding organisation and
-        # restrict qualifications to those available to learners
-        organisations = await client.search()
+        # Restrict qualifications to Pearson Education and those available to learners
         qualifications = await client.search_qualifications(course=Title)
 
     return templates.TemplateResponse(
@@ -1445,7 +1442,6 @@ async def ofqual_search(
             "Title": Title,
             "Num": Num,
             "Status": Status,
-            "organisations": organisations,
             "qualifications": qualifications,
         },
     )

--- a/templates/ofqual_search.html
+++ b/templates/ofqual_search.html
@@ -58,13 +58,4 @@
     </div>
 
 </div>
-<script>
-    const radios = document.querySelectorAll('input[name="organisation_id"]');
-    const nameInput = document.getElementById('organisation_name');
-    radios.forEach(r => {
-        r.addEventListener('change', () => {
-            nameInput.value = r.dataset.orgName;
-        });
-    });
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Only fetch qualifications, excluding unused awarding org lookup
- Clean up Ofqual search template and ensure Pearson-specific query

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dd3d33238832c8b7df2cbdcdde12a