### PR TITLE
Fix Ofqual qualification search

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1429,14 +1429,8 @@ async def ofqual_search(
     The remaining filter parameters are accepted for future use.
     """
     client = OfqualAOSearchClient()
-    organisations: List[Dict] = []
-    qualifications: List[Dict] = []
-
-    if Title:
-        # Always look up the Pearson Education awarding organisation and
-        # restrict qualifications to those available to learners
-        organisations = await client.search()
-        qualifications = await client.search_qualifications(course=Title)
+    # Always search qualifications for Pearson Education, filtering by title if provided
+    qualifications: List[Dict] = await client.search_qualifications(course=Title)
 
     return templates.TemplateResponse(
         "ofqual_search.html",
@@ -1445,7 +1439,6 @@ async def ofqual_search(
             "Title": Title,
             "Num": Num,
             "Status": Status,
-            "organisations": organisations,
             "qualifications": qualifications,
         },
     )

--- a/templates/ofqual_search.html
+++ b/templates/ofqual_search.html
@@ -39,6 +39,7 @@
                 <thead class="bg-gray-50">
                     <tr>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Awarding organisation</th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Number</th>
                         <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Availability</th>
                     </tr>
@@ -47,6 +48,7 @@
                     {% for qual in qualifications %}
                     <tr class="hover:bg-gray-50">
                         <td class="px-4 py-2">{{ qual.title or qual['title'] }}</td>
+                        <td class="px-4 py-2">{{ qual.awardingOrganisation or qual['awardingOrganisation'] }}</td>
                         <td class="px-4 py-2">{{ qual.qualificationNumber or qual['qualificationNumber'] }}</td>
                         <td class="px-4 py-2">{{ qual.availability or qual['availability'] }}</td>
                     </tr>
@@ -58,13 +60,4 @@
     </div>
 
 </div>
-<script>
-    const radios = document.querySelectorAll('input[name="organisation_id"]');
-    const nameInput = document.getElementById('organisation_name');
-    radios.forEach(r => {
-        r.addEventListener('change', () => {
-            nameInput.value = r.dataset.orgName;
-        });
-    });
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Always query Ofqual qualifications for Pearson Education, filtering by title when provided
- Show awarding organisation alongside qualification results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dd3d33238832c8b7df2cbdcdde12a