### PR TITLE
Assess safeguarding policies with AI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ import asyncio
 import uuid
 import aiohttp
 import requests
+import logging
 
 
 def secure_filename(filename: str) -> str:
@@ -52,6 +53,7 @@ from app.vc_issue import create_verifiable_credential
 from app.vc_verify import verify_credential
 from app.qr_utils import generate_qr_code
 from app.pdf_utils import generate_credential_pdf
+from app.services.safeguarding_assessment import assess_safeguarding_policy
 from app.centre_submission import (
     CentreSubmission,
     ParentOrganisation,
@@ -71,6 +73,10 @@ processing_queue = {}
 documents_storage: Dict[str, List[Dict]] = {}
 # Directory to store uploaded files
 UPLOAD_DIR = os.path.join("app", "static", "uploads")
+
+# Logging configuration
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # MCP wrapper instance (created during startup)
 mcp_wrapper: KYCContextSource | None = None
@@ -377,6 +383,11 @@ async def documents(request: Request):
     if not user:
         return RedirectResponse("/login", status_code=302)
     user_docs = documents_storage.get(user["name"], [])
+    logger.info(
+        "Rendering documents page for %s with %d documents",
+        user["name"],
+        len(user_docs),
+    )
     return templates.TemplateResponse(
         "documents.html", {"request": request, "user": user, "documents": user_docs}
     )
@@ -404,11 +415,19 @@ async def upload_user_documents(request: Request, files: List[UploadFile] = File
                 if not chunk:
                     break
                 out.write(chunk)
+        assessment = None
+        assessment_rationale = None
+        if "safeguard" in filename.lower():
+            logger.info("Assessing safeguarding policy for %s", filename)
+            assessment, assessment_rationale = await assess_safeguarding_policy(path)
+            logger.info("Assessment result for %s: %s", filename, assessment)
         user_docs.append(
             {
                 "name": file.filename,
                 "stored_name": stored_name,
                 "uploaded_at": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+                "assessment": assessment,
+                "assessment_rationale": assessment_rationale,
             }
         )
         saved.append(file.filename)

--- a/app/services/safeguarding_assessment.py
+++ b/app/services/safeguarding_assessment.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import logging
+from datetime import datetime
+from typing import Optional, Tuple
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai optional
+    OpenAI = None  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_text(path: str) -> str:
+    """Return best-effort text extraction from the uploaded file."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            return f.read()
+    except Exception:
+        return ""
+
+
+def _heuristic_classification(text: str) -> Tuple[str, str]:
+    """Fallback rule-based safeguarding assessment.
+
+    Returns a tuple of (rating, rationale) where rationale is a
+    two-sentence explanation of the rating.
+    """
+    lower = text.lower()
+    if "safeguarding" not in lower or "policy" not in lower:
+        rationale = (
+            "The document does not clearly reference a safeguarding policy. "
+            "It therefore appears irrelevant or missing."
+        )
+        return "red", rationale
+    match = re.search(r"20\d{2}", text)
+    if match:
+        year = int(match.group())
+        if year >= datetime.utcnow().year - 2:
+            rationale = (
+                "The document references safeguarding policy and includes a recent date. "
+                "It appears relevant and up to date."
+            )
+            return "green", rationale
+    rationale = (
+        "The document mentions safeguarding but may be incomplete or outdated. "
+        "Consider reviewing and updating the policy."
+    )
+    return "amber", rationale
+
+
+async def assess_safeguarding_policy(path: str) -> Tuple[str, str]:
+    """Assess a safeguarding policy document and return rating and rationale."""
+    text = _extract_text(path)
+    api_key = os.getenv("OPENAI_API_KEY")
+
+    if api_key and OpenAI:
+        logger.info("Assessing safeguarding policy using OpenAI LLM")
+        client = OpenAI(api_key=api_key)
+        system_prompt = (
+            "You analyse learning centre safeguarding policy documents. "
+            "Given a document, respond with the rating GREEN, AMBER, or RED on the first line "
+            "followed by two sentences explaining the rating."
+        )
+        try:
+            response = await asyncio.to_thread(
+                lambda: client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": text[:6000]},
+                    ],
+                    max_tokens=150,
+                )
+            )
+            content = response.choices[0].message.content.strip()
+            lines = content.splitlines()
+            rating_line = lines[0].strip().lower() if lines else ""
+            rationale = " ".join(line.strip() for line in lines[1:]).strip()
+            if "green" in rating_line:
+                logger.info("Safeguarding assessment generated via OpenAI: green")
+                return "green", rationale
+            if "amber" in rating_line or "yellow" in rating_line:
+                logger.info("Safeguarding assessment generated via OpenAI: amber")
+                return "amber", rationale
+            if "red" in rating_line:
+                logger.info("Safeguarding assessment generated via OpenAI: red")
+                return "red", rationale
+        except Exception as exc:
+            logger.warning("OpenAI safeguarding assessment failed: %s", exc)
+
+    logger.info("Using heuristic safeguarding assessment")
+    return _heuristic_classification(text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ SQLAlchemy==2.0.23
 psycopg2-binary==2.9.9
 httpx==0.26.0
 reportlab==4.0.5
+
+openai>=1.3.5

--- a/templates/documents.html
+++ b/templates/documents.html
@@ -28,6 +28,8 @@
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Doc ID</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Format</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assessment</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rationale</th>
                 <th class="px-4 py-2"></th>
                 <th class="px-4 py-2"></th>
             </tr>
@@ -38,6 +40,20 @@
                 <td class="px-4 py-2 text-sm text-gray-900">{{ loop.index }}</td>
                 <td class="px-4 py-2 text-sm"><a href="/static/uploads/{{ doc.stored_name }}" class="text-blue-600 hover:underline">{{ doc.name }}</a></td>
                 <td class="px-4 py-2 text-sm text-gray-500">{{ doc.name.split('.')[-1].upper() }}</td>
+                <td class="px-4 py-2 text-sm">
+                    {% if doc.assessment == 'green' %}
+                    <span class="text-green-600 font-semibold">Green</span>
+                    {% elif doc.assessment == 'amber' %}
+                    <span class="text-yellow-600 font-semibold">Amber</span>
+                    {% elif doc.assessment == 'red' %}
+                    <span class="text-red-600 font-semibold">Red</span>
+                    {% else %}
+                    <span class="text-gray-400">N/A</span>
+                    {% endif %}
+                </td>
+                <td class="px-4 py-2 text-sm text-gray-700">
+                    {{ doc.assessment_rationale or '' }}
+                </td>
                 <td class="px-4 py-2 text-center">
                     <a href="#" title="Attach to application" class="text-indigo-600 hover:text-indigo-900">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -54,44 +70,6 @@
                 </td>
             </tr>
             {% endfor %}
-            <tr>
-                <td class="px-4 py-2 text-sm text-gray-900">DOC001</td>
-                <td class="px-4 py-2 text-sm text-blue-600 hover:underline">Centre Policy</td>
-                <td class="px-4 py-2 text-sm text-gray-500">PDF</td>
-                <td class="px-4 py-2 text-center">
-                    <a href="#" title="Attach to application" class="text-indigo-600 hover:text-indigo-900">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.364 6.364a4 4 0 105.656 5.656l6.364-6.364a4 4 0 00-5.656-5.656L9 10.828" />
-                        </svg>
-                    </a>
-                </td>
-                <td class="px-4 py-2 text-center">
-                    <a href="#" title="Share by email" class="text-indigo-600 hover:text-indigo-900">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                        </svg>
-                    </a>
-                </td>
-            </tr>
-            <tr>
-                <td class="px-4 py-2 text-sm text-gray-900">DOC002</td>
-                <td class="px-4 py-2 text-sm text-blue-600 hover:underline">Staff List</td>
-                <td class="px-4 py-2 text-sm text-gray-500">XLSX</td>
-                <td class="px-4 py-2 text-center">
-                    <a href="#" title="Attach to application" class="text-indigo-600 hover:text-indigo-900">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.364 6.364a4 4 0 105.656 5.656l6.364-6.364a4 4 0 00-5.656-5.656L9 10.828" />
-                        </svg>
-                    </a>
-                </td>
-                <td class="px-4 py-2 text-center">
-                    <a href="#" title="Share by email" class="text-indigo-600 hover:text-indigo-900">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                        </svg>
-                    </a>
-                </td>
-            </tr>
         </tbody>
     </table>
 </div>
@@ -149,4 +127,3 @@ document.getElementById('uploadForm').addEventListener('submit', function(e) {
 });
 </script>
 {% endblock %}
-

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,18 +1,49 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from fastapi.testclient import TestClient
-from app.main import app
+from app.main import app, documents_storage
+from datetime import datetime
 
 client = TestClient(app)
 
 def test_documents_upload_requires_auth():
+    documents_storage.clear()
     resp = client.post("/documents/upload", files={"files": ("test.txt", b"hi")})
     assert resp.status_code == 401
 
 
 def test_documents_upload_success():
-    # login first
+    documents_storage.clear()
     client.post("/login", data={"username": "centre1", "password": "centrepass"})
     resp = client.post("/documents/upload", files={"files": ("test.txt", b"hi")})
     assert resp.status_code == 200
     assert resp.json().get("success")
+
+
+def test_safeguarding_policy_assessment():
+    documents_storage.clear()
+    client.post("/login", data={"username": "centre1", "password": "centrepass"})
+    content = b"Safeguarding Policy for 2024 ensures child safety."
+    resp = client.post(
+        "/documents/upload",
+        files={"files": ("safeguarding_policy.txt", content)},
+    )
+    assert resp.status_code == 200
+    docs = documents_storage["Example Learning Centre"]
+    assert docs[-1]["assessment"] == "green"
+    assert docs[-1]["assessment_rationale"]
+
+
+def test_documents_page_shows_assessment_and_rationale():
+    documents_storage.clear()
+    client.post("/login", data={"username": "centre1", "password": "centrepass"})
+    year = datetime.utcnow().year
+    content = f"Safeguarding Policy for {year} ensures child safety.".encode()
+    client.post(
+        "/documents/upload",
+        files={"files": ("safeguarding_policy.txt", content)},
+    )
+    resp = client.get("/documents")
+    assert resp.status_code == 200
+    assert "Green" in resp.text
+    assert "It appears relevant and up to date." in resp.text


### PR DESCRIPTION
## Summary
- request AI safeguarding assessment to return a colour rating plus two-sentence rationale
- persist rating and rationale on upload and display rationale column on documents page
- extend document upload test to assert rationale is stored
- log assessment generation path (OpenAI vs heuristic) and document page rendering

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e58570da4832c973600c65bda13a8