### PR TITLE
feat: add automatic image relevance analysis

### DIFF
--- a/app/services/image_relevance.py
+++ b/app/services/image_relevance.py
@@ -1,0 +1,55 @@
+import base64
+import logging
+import os
+from typing import Literal
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai might not be installed during tests
+    OpenAI = None
+
+ImageAssessment = Literal["green", "amber", "red"]
+
+logger = logging.getLogger(__name__)
+
+async def assess_image_relevance(path: str) -> ImageAssessment:
+    """Assess whether an image is relevant to a teaching environment.
+
+    Uses a vision-capable model and returns GREEN, AMBER or RED. Defaults to RED
+    if the model or API is unavailable.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or OpenAI is None:
+        logger.warning("OpenAI not configured; defaulting image assessment to RED")
+        return "red"
+    try:
+        with open(path, "rb") as f:
+            img_bytes = f.read()
+        b64_img = base64.b64encode(img_bytes).decode("ascii")
+        prompt = (
+            "Is this image relevant to a college teaching or learning environment? "
+            "Respond with one word: GREEN if relevant, RED if not."
+        )
+        client = OpenAI(api_key=api_key)
+        resp = client.responses.create(
+            model="gpt-4o-mini",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": prompt},
+                        {"type": "input_image", "image": b64_img},
+                    ],
+                }
+            ],
+            max_output_tokens=1,
+        )
+        result = resp.output_text.strip().lower()
+        if result.startswith("green"):
+            return "green"
+        if result.startswith("amber"):
+            return "amber"
+        return "red"
+    except Exception as exc:  # pragma: no cover - external API may fail
+        logger.warning("Image assessment failed: %s", exc)
+        return "red"

--- a/templates/documents.html
+++ b/templates/documents.html
@@ -28,6 +28,7 @@
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Doc ID</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Format</th>
+                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Image Relevance</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assessment</th>
                 <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rationale</th>
                 <th class="px-4 py-2"></th>
@@ -40,6 +41,20 @@
                 <td class="px-4 py-2 text-sm text-gray-900">{{ loop.index }}</td>
                 <td class="px-4 py-2 text-sm"><a href="/static/uploads/{{ doc.stored_name }}" class="text-blue-600 hover:underline">{{ doc.name }}</a></td>
                 <td class="px-4 py-2 text-sm text-gray-500">{{ doc.name.split('.')[-1].upper() }}</td>
+                <td class="px-4 py-2 text-sm">
+                    {% if doc.image_relevance %}
+                        <form method="post" action="/documents/{{ loop.index0 }}/classify" class="flex space-x-1 items-center">
+                            <select name="classification" class="border rounded text-xs">
+                                {% for opt in ['green','amber','red'] %}
+                                    <option value="{{ opt }}" {% if doc.image_relevance==opt %}selected{% endif %}>{{ opt.upper() }}</option>
+                                {% endfor %}
+                            </select>
+                            <button type="submit" class="text-blue-600 text-xs">Update</button>
+                        </form>
+                    {% else %}
+                        <span class="text-gray-400">N/A</span>
+                    {% endif %}
+                </td>
                 <td class="px-4 py-2 text-sm">
                         {% if doc.assessment %}
                             {% set colour = 'bg-gray-300' %}

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -41,6 +41,41 @@ def test_safeguarding_policy_assessment():
     assert docs[-1]["assessment_rationale"]
 
 
+def test_image_upload_classification_default_red():
+    documents_storage.clear()
+    client.post("/login", data={"username": "centre1", "password": "centrepass"})
+    # 1x1 PNG pixel
+    img = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        b"\x00\x00\x00\nIDATx\xdac\xf8\x0f\x00\x01\x01\x01\x00\x18\xdd\x8d\xc5\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    resp = client.post(
+        "/documents/upload", files={"files": ("class.png", img, "image/png")}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["assessments"][0]["image_relevance"] == "red"
+    docs = documents_storage["Example Learning Centre"]
+    assert docs[-1]["image_relevance"] == "red"
+
+
+def test_override_image_classification():
+    documents_storage.clear()
+    client.post("/login", data={"username": "centre1", "password": "centrepass"})
+    img = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        b"\x00\x00\x00\nIDATx\xdac\xf8\x0f\x00\x01\x01\x01\x00\x18\xdd\x8d\xc5\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    client.post(
+        "/documents/upload", files={"files": ("class.png", img, "image/png")}
+    )
+    resp = client.post(
+        "/documents/0/classify", data={"classification": "green"}, allow_redirects=False
+    )
+    assert resp.status_code == 303
+    assert documents_storage["Example Learning Centre"][0]["image_relevance"] == "green"
+
+
 def test_documents_page_shows_assessment_and_rationale():
     documents_storage.clear()
     client.post("/login", data={"username": "centre1", "password": "centrepass"})


### PR DESCRIPTION
## Summary
- analyze uploaded images with GPT-4o mini to flag GREEN/RED relevance
- show and override image relevance in document table
- cover classification and override with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f300043e4832c9bbb4440ff1d7b94