### PR TITLE
Capture onboarding submissions as centre applications

### DIFF
--- a/templates/applications.html
+++ b/templates/applications.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Applications{% endblock %}
+{% block content %}
+<div class="max-w-7xl mx-auto">
+    {% if user %}
+    <p class="text-sm text-gray-600 mb-4">Logged in as {{ user.name }} ({{ user.role.replace('_',' ')|title }})</p>
+    {% endif %}
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold text-gray-900">Qualification Applications</h1>
+        <p class="text-gray-600 mt-2">Applications submitted through onboarding</p>
+    </div>
+    <div class="bg-white rounded-lg shadow-md overflow-hidden">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Awarding Organisation</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">OFQUAL Centre Number (RN)</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Qualification Number</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Qualification Title</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                {% for app in applications %}
+                <tr>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ app.awarding_organisation }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ app.rn }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-900">{{ app.qualification_number }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ app.qualification_title }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ app.status }}</td>
+                </tr>
+                {% endfor %}
+                {% if not applications %}
+                <tr>
+                    <td class="px-6 py-4 text-center text-sm text-gray-500" colspan="5">No applications yet</td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- persist qualification application entries in memory when onboarding a provider
- add Centre Dashboard page showing awarding org, centre RN, qualification details and pending status
- handle JSON payloads in `/onboard` handler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9d50d9c4832c977875053cf8b360