### PR TITLE
Link Ofqual search results and add selection helper

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -504,6 +504,8 @@ async def centre_submission_form(
     request: Request,
     organisation_id: Optional[str] = None,
     organisation_name: Optional[str] = None,
+    qualification_id: Optional[str] = None,
+    qualification_title: Optional[str] = None,
 ):
     return templates.TemplateResponse(
         "centre_submission_form.html",
@@ -511,6 +513,8 @@ async def centre_submission_form(
             "request": request,
             "organisation_id": organisation_id,
             "organisation_name": organisation_name,
+            "qualification_id": qualification_id,
+            "qualification_title": qualification_title,
         },
     )
 

--- a/templates/centre_submission_form.html
+++ b/templates/centre_submission_form.html
@@ -23,7 +23,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2" for="qualification_id">Qualification ID</label>
-                    <input type="text" id="qualification_id" name="qualification_id" required class="w-full border border-gray-300 rounded-md px-3 py-2">
+                    <input type="text" id="qualification_id" name="qualification_id" value="{{ qualification_id or '' }}" required class="w-full border border-gray-300 rounded-md px-3 py-2">
                 </div>
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2" for="ao_id">Awarding Org ID</label>
@@ -35,7 +35,7 @@
                 </div>
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2" for="title">Qualification Title</label>
-                    <input type="text" id="title" name="title" required class="w-full border border-gray-300 rounded-md px-3 py-2">
+                    <input type="text" id="title" name="title" value="{{ qualification_title or '' }}" required class="w-full border border-gray-300 rounded-md px-3 py-2">
                 </div>
                 <div>
                     <label class="block text-sm font-medium text-gray-700 mb-2" for="start_date">Start Date</label>

--- a/templates/ofqual_search.html
+++ b/templates/ofqual_search.html
@@ -15,14 +15,23 @@
           <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
           <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Number</th>
           <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Availability</th>
+          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Select</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200">
         {% for qual in qualifications %}
+        {% set title = qual.title or qual['title'] %}
+        {% set number = qual.qualificationNumber or qual['qualificationNumber'] %}
+        {% set availability = qual.availability or qual['availability'] %}
         <tr class="hover:bg-gray-50">
-          <td class="px-4 py-2">{{ qual.title or qual['title'] }}</td>
-          <td class="px-4 py-2">{{ qual.qualificationNumber or qual['qualificationNumber'] }}</td>
-          <td class="px-4 py-2">{{ qual.availability or qual['availability'] }}</td>
+          <td class="px-4 py-2">
+            <a class="text-blue-600 underline" href="https://find-a-qualification.services.ofqual.gov.uk/qualifications/{{ number }}" target="_blank" rel="noopener">{{ title }}</a>
+          </td>
+          <td class="px-4 py-2">{{ number }}</td>
+          <td class="px-4 py-2">{{ availability }}</td>
+          <td class="px-4 py-2">
+            <a class="govuk-button govuk-button--secondary" href="/centre-submission?qualification_id={{ number }}&qualification_title={{ title | urlencode }}">Select</a>
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_centre_submission_prefill.py
+++ b/tests/test_centre_submission_prefill.py
@@ -1,0 +1,13 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from starlette.testclient import TestClient
+from app.main import app
+
+
+def test_centre_submission_prefills_fields():
+    client = TestClient(app)
+    resp = client.get("/centre-submission", params={"qualification_id": "123", "qualification_title": "History A Level"})
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'value="123"' in html
+    assert 'value="History A Level"' in html


### PR DESCRIPTION
## Summary
- Link each Ofqual search result to the qualification details page
- Add "Select" buttons that populate qualification fields in the centre submission form
- Prefill centre submission form fields from query parameters

## Testing
- `pytest tests/test_centre_submission_prefill.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689044b22e7c832ca8bd688982683f27