### PR TITLE
Populate applications from centre submissions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -571,6 +571,18 @@ async def submit_centre_submission(request: Request):
 
     centre_submissions.append(submission)
 
+    # Add entry to applications list for display on /applications page
+    applications_db.append(
+        {
+            "id": len(applications_db) + 1,
+            "awarding_organisation": form.get("ao_name"),
+            "rn": form.get("ao_id"),
+            "qualification_number": form.get("qualification_id"),
+            "qualification_title": form.get("title"),
+            "status": "Pending",
+        }
+    )
+
     return templates.TemplateResponse(
         "centre_submission_success.html", {"request": request, "submission": submission}
     )
@@ -626,22 +638,7 @@ async def onboard_provider(request: Request, background_tasks: BackgroundTasks):
     }
 
     providers_db.append(new_provider)
-    # Also capture a corresponding qualification application entry
-    applications_db.append(
-        {
-            "id": len(applications_db) + 1,
-            "provider_organisation": provider_data["organisation_name"],
-            "postcode": provider_data.get("postcode"),
-            "provider_type": provider_data.get("provider_type"),
-            "company_number": provider_data.get("company_number"),
-            "urn": provider_data.get("urn"),
-            "awarding_organisation": "Pearson",
-            "rn": "RN153",
-            "qualification_number": "601/1234/X",
-            "qualification_title": "Level 3 Diploma in Childcare",
-            "status": "Pending",
-        }
-    )
+    # Application entries now originate from centre submissions
     processing_queue[verification_id] = "started"
 
     # Start orchestrated KYC verification

--- a/templates/applications.html
+++ b/templates/applications.html
@@ -7,7 +7,7 @@
     {% endif %}
     <div class="mb-8">
         <h1 class="text-3xl font-bold text-gray-900">Qualification Applications</h1>
-        <p class="text-gray-600 mt-2">Applications submitted through onboarding</p>
+        <p class="text-gray-600 mt-2">Applications added via centre submission</p>
     </div>
     <div class="bg-white rounded-lg shadow-md overflow-hidden">
         <table class="min-w-full divide-y divide-gray-200">

--- a/tests/test_applications_from_centre_submission.py
+++ b/tests/test_applications_from_centre_submission.py
@@ -1,0 +1,43 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from starlette.testclient import TestClient
+from app.main import app, applications_db
+
+
+def test_centre_submission_populates_applications_table():
+    client = TestClient(app)
+    applications_db.clear()
+    data = {
+        "verification_id": "verif123",
+        "qualification_id": "QUAL123",
+        "ao_id": "AO999",
+        "ao_name": "Test Awarding Org",
+        "title": "Test Qualification",
+        "start_date": "2025-09-01",
+        "cohort_size": "30",
+        "staff_id": "S1",
+        "staff_role": "Manager",
+        "staff_name": "Alice",
+        "staff_email": "alice@example.com",
+        "ofqual_ack": "on",
+        "gdpr_consent": "on",
+        "share_aos": "on",
+        # Additional fields required by handler
+        "group_ukprn": "G123",
+        "legal_name": "My Org",
+        "organisation_type": "College",
+        "address_line1": "1 Street",
+        "postcode": "AB1 2CD",
+        "site_id": "SITE1",
+        "site_ukprn": "10000001",
+        "site_name": "Main Site",
+    }
+    resp = client.post("/centre-submission", data=data)
+    assert resp.status_code == 200
+    assert len(applications_db) == 1
+    app_entry = applications_db[0]
+    assert app_entry["awarding_organisation"] == "Test Awarding Org"
+    assert app_entry["rn"] == "AO999"
+    assert app_entry["qualification_number"] == "QUAL123"
+    assert app_entry["qualification_title"] == "Test Qualification"
+


### PR DESCRIPTION
## Summary
- Populate applications table when centre submission form is submitted
- Remove onboarding logic that added placeholder application entries
- Update applications page copy and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890606c8518832cb4208c64a43436cc