### PR TITLE
Show applications list after centre submission

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -583,8 +583,11 @@ async def submit_centre_submission(request: Request):
         }
     )
 
+    # After adding to our in-memory store, show the updated applications table
+    user = get_current_user(request)
     return templates.TemplateResponse(
-        "centre_submission_success.html", {"request": request, "submission": submission}
+        "applications.html",
+        {"request": request, "applications": applications_db, "user": user},
     )
 
 

--- a/templates/centre_submission_form.html
+++ b/templates/centre_submission_form.html
@@ -88,7 +88,10 @@
         </div>
         <div class="pt-6 flex justify-between">
             <a href="/" class="text-gray-600 hover:text-gray-800">← Back to Dashboard</a>
-            <button type="submit" class="bg-blue-600 text-white px-8 py-3 rounded-md hover:bg-blue-700">Add to application pack</button>
+            <div class="text-right">
+                <p class="text-xs text-gray-500 mb-1">Adds this qualification to your application pack.</p>
+                <button type="submit" class="bg-blue-600 text-white px-8 py-3 rounded-md hover:bg-blue-700">Add to application pack</button>
+            </div>
         </div>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- Display the applications table after a centre submission is saved
- Clarify that the submit button adds a qualification to the application pack

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68906ac8997c832cab046adb52584854