### PR TITLE
Add course recommendation engine with frontend

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 # app/main.py - Updated with Educational KYC Orchestrator Integration
 
-from fastapi import FastAPI, Request, BackgroundTasks, Form, UploadFile, File
+from fastapi import FastAPI, Request, BackgroundTasks, Form, UploadFile, File, HTTPException
 from fastapi.responses import RedirectResponse, Response
 from starlette.middleware.sessions import SessionMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -66,6 +66,20 @@ from app.centre_submission import (
     ComplianceDeclarations,
 )
 from app.services.safeguarding_assessor import assess_safeguarding_document
+
+import importlib
+
+try:
+    from backend.recommend import app as recommend_api
+    RECOMMENDER_AVAILABLE = True
+except Exception:
+    recommend_api = None
+    RECOMMENDER_AVAILABLE = False
+
+try:
+    from backend.etl import run_etl
+except Exception:
+    run_etl = None
 
 # In-memory storage for demo
 providers_db = []
@@ -236,6 +250,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(SessionMiddleware, secret_key=os.getenv("SESSION_SECRET", "super-secret"))
+
+# Mount recommendation API routes
+if RECOMMENDER_AVAILABLE:
+    app.include_router(recommend_api.router)
 
 # Templates setup
 templates = Jinja2Templates(directory="templates")
@@ -567,7 +585,11 @@ async def centre_submission_form(
     organisation_name: Optional[str] = None,
     qualification_id: Optional[str] = None,
     qualification_title: Optional[str] = None,
-):
+): 
+    user = get_current_user(request)
+    centre_id = 1 if user and user.get("role") == "learning_centre" else None
+    recommend_available = (run_etl is not None) or RECOMMENDER_AVAILABLE
+
     return templates.TemplateResponse(
         "centre_submission_form.html",
         {
@@ -576,8 +598,32 @@ async def centre_submission_form(
             "organisation_name": organisation_name,
             "qualification_id": qualification_id,
             "qualification_title": qualification_title,
+            "centre_id": centre_id,
+            "recommend_available": recommend_available,
         },
     )
+
+
+@app.post("/build-recommendations")
+async def build_recommendations():
+    if run_etl is None:
+        raise HTTPException(status_code=500, detail="ETL not configured")
+    try:
+        run_etl()
+        import backend.recommend as recommend_module
+        importlib.reload(recommend_module)
+        # remove existing recommendation routes if any
+        app.router.routes = [
+            r
+            for r in app.router.routes
+            if not getattr(r, "path", "").startswith("/recommend")
+        ]
+        app.include_router(recommend_module.app.router)
+        global RECOMMENDER_AVAILABLE
+        RECOMMENDER_AVAILABLE = True
+        return {"status": "ok"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @app.post("/centre-submission")

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,17 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@localhost:5432/training")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+def get_session():
+    """Yield a SQLAlchemy session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/etl.py
+++ b/backend/etl.py
@@ -1,0 +1,108 @@
+"""ETL script to build feature matrices for centres and courses."""
+import os
+import numpy as np
+import joblib
+from scipy.sparse import hstack, csr_matrix
+from sqlalchemy.orm import joinedload
+from sklearn.feature_extraction import DictVectorizer
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+from .database import SessionLocal
+from .models import Centre, Course
+
+
+def run_etl(output_dir: str = None):
+    output_dir = output_dir or os.path.join(os.path.dirname(__file__), "data")
+    os.makedirs(output_dir, exist_ok=True)
+
+    session = SessionLocal()
+    try:
+        centres = (
+            session.query(Centre)
+            .options(joinedload(Centre.labs), joinedload(Centre.skills))
+            .all()
+        )
+        courses = session.query(Course).all()
+
+        centre_lab_dicts, centre_skill_dicts, centre_ratings, centre_meta = [], [], [], []
+        course_lab_dicts, course_skill_dicts, course_meta = [], [], []
+
+        for c in centres:
+            lab_dict = {lab.lab_type: lab.capability for lab in c.labs}
+            skill_dict = {s.skill: s.level for s in c.skills}
+            centre_lab_dicts.append(lab_dict)
+            centre_skill_dicts.append(skill_dict)
+            rating = c.online_rating or 0.0
+            centre_ratings.append(rating)
+            centre_meta.append(
+                {
+                    "id": c.id,
+                    "name": c.name,
+                    "lab_capabilities": lab_dict,
+                    "skill_levels": skill_dict,
+                    "labs": list(lab_dict.keys()),
+                    "skills": list(skill_dict.keys()),
+                    "online_rating": rating,
+                }
+            )
+
+        for crs in courses:
+            lab_req = crs.min_lab_req or []
+            skill_req = crs.skill_prereqs or []
+            course_lab_dicts.append({lab: 1.0 for lab in lab_req})
+            course_skill_dicts.append({sk: 1.0 for sk in skill_req})
+            course_meta.append(
+                {
+                    "id": crs.id,
+                    "title": crs.title,
+                    "delivery_mode": crs.delivery_mode,
+                    "min_lab_req": lab_req,
+                    "skill_prereqs": skill_req,
+                    "online_content_ok": crs.online_content_ok,
+                }
+            )
+
+        lab_vec = DictVectorizer()
+        lab_vec.fit(centre_lab_dicts + course_lab_dicts)
+        skill_vec = DictVectorizer()
+        skill_vec.fit(centre_skill_dicts + course_skill_dicts)
+
+        delivery_enc = OneHotEncoder(handle_unknown="ignore")
+        delivery_enc.fit([[c["delivery_mode"]] for c in course_meta])
+
+        rating_scaler = StandardScaler().fit(np.array(centre_ratings).reshape(-1, 1))
+
+        centre_lab_matrix = lab_vec.transform(centre_lab_dicts)
+        centre_skill_matrix = skill_vec.transform(centre_skill_dicts)
+        centre_rating_matrix = rating_scaler.transform(np.array(centre_ratings).reshape(-1, 1))
+        centre_delivery_zeros = csr_matrix(
+            np.zeros((centre_lab_matrix.shape[0], len(delivery_enc.categories_[0])))
+        )
+        centre_online_zeros = csr_matrix(np.zeros((centre_lab_matrix.shape[0], 1)))
+        centre_features = hstack(
+            [centre_lab_matrix, centre_skill_matrix, centre_rating_matrix, centre_delivery_zeros, centre_online_zeros]
+        ).toarray()
+
+        course_lab_matrix = lab_vec.transform(course_lab_dicts)
+        course_skill_matrix = skill_vec.transform(course_skill_dicts)
+        course_delivery_matrix = delivery_enc.transform(
+            [[c["delivery_mode"]] for c in course_meta]
+        )
+        course_online_matrix = csr_matrix(
+            np.array([[1.0 if c["online_content_ok"] else 0.0] for c in course_meta])
+        )
+        course_rating_zeros = csr_matrix(np.zeros((len(course_meta), 1)))
+        course_features = hstack(
+            [course_lab_matrix, course_skill_matrix, course_rating_zeros, course_delivery_matrix, course_online_matrix]
+        ).toarray()
+
+        joblib.dump(centre_features, os.path.join(output_dir, "centre_feature_matrix.pkl"))
+        joblib.dump(course_features, os.path.join(output_dir, "course_feature_matrix.pkl"))
+        joblib.dump(centre_meta, os.path.join(output_dir, "centre_metadata.pkl"))
+        joblib.dump(course_meta, os.path.join(output_dir, "course_metadata.pkl"))
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    run_etl()

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,58 @@
+from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey, ARRAY, Text
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class Centre(Base):
+    __tablename__ = "centres"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    location = Column(String)
+    capacity = Column(Integer)
+    online_rating = Column(Float)
+
+    labs = relationship("CentreLab", back_populates="centre", cascade="all, delete-orphan")
+    skills = relationship("CentreStaffSkill", back_populates="centre", cascade="all, delete-orphan")
+
+
+class CentreLab(Base):
+    __tablename__ = "centre_labs"
+    id = Column(Integer, primary_key=True)
+    centre_id = Column(Integer, ForeignKey("centres.id"))
+    lab_type = Column(String, nullable=False)
+    capability = Column(Float, default=0.0)
+
+    centre = relationship("Centre", back_populates="labs")
+
+
+class CentreStaffSkill(Base):
+    __tablename__ = "centre_staff_skills"
+    id = Column(Integer, primary_key=True)
+    centre_id = Column(Integer, ForeignKey("centres.id"))
+    skill = Column(String, nullable=False)
+    level = Column(Float, default=0.0)
+
+    centre = relationship("Centre", back_populates="skills")
+
+
+class Course(Base):
+    __tablename__ = "courses"
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    description = Column(Text)
+    delivery_mode = Column(String, nullable=False)
+    min_lab_req = Column(ARRAY(String), default=list)
+    skill_prereqs = Column(ARRAY(String), default=list)
+    online_content_ok = Column(Boolean, default=False)
+
+    tags = relationship("CourseTag", back_populates="course", cascade="all, delete-orphan")
+
+
+class CourseTag(Base):
+    __tablename__ = "course_tags"
+    id = Column(Integer, primary_key=True)
+    course_id = Column(Integer, ForeignKey("courses.id"))
+    tag = Column(String, nullable=False)
+
+    course = relationship("Course", back_populates="tags")

--- a/backend/recommend.py
+++ b/backend/recommend.py
@@ -1,0 +1,58 @@
+"""Recommendation API using precomputed feature matrices."""
+import os
+from typing import List
+
+import joblib
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from sklearn.metrics.pairwise import cosine_similarity
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+centre_features = joblib.load(os.path.join(DATA_DIR, "centre_feature_matrix.pkl"))
+course_features = joblib.load(os.path.join(DATA_DIR, "course_feature_matrix.pkl"))
+centre_meta = joblib.load(os.path.join(DATA_DIR, "centre_metadata.pkl"))
+course_meta = joblib.load(os.path.join(DATA_DIR, "course_metadata.pkl"))
+centre_index = {c["id"]: idx for idx, c in enumerate(centre_meta)}
+
+app = FastAPI()
+
+
+@app.get("/recommend/{centre_id}")
+def recommend(centre_id: int, top_n: int = 10):
+    if centre_id not in centre_index:
+        raise HTTPException(status_code=404, detail="Centre not found")
+
+    idx = centre_index[centre_id]
+    centre_vec = centre_features[idx : idx + 1]
+    centre_info = centre_meta[idx]
+    owned_labs = set(centre_info["labs"])
+    rating = centre_info["online_rating"]
+
+    sims = cosine_similarity(centre_vec, course_features)[0]
+    results: List[dict] = []
+    for j, course in enumerate(course_meta):
+        if not set(course["min_lab_req"]).issubset(owned_labs):
+            continue
+        if course["online_content_ok"] and rating < 3.0:
+            continue
+        results.append(
+            {
+                "id": course["id"],
+                "title": course["title"],
+                "delivery_mode": course["delivery_mode"],
+                "min_lab_req": course["min_lab_req"],
+                "skill_prereqs": course["skill_prereqs"],
+                "score": float(sims[j]),
+            }
+        )
+
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return {
+        "centre": {
+            "id": centre_id,
+            "lab_capabilities": centre_info["lab_capabilities"],
+            "skill_levels": centre_info["skill_levels"],
+        },
+        "recommendations": results[:top_n],
+    }

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -1,0 +1,102 @@
+const { useState, useEffect, useRef } = React;
+
+function RadarChart({ centre, course }) {
+  const canvasRef = useRef(null);
+  useEffect(() => {
+    const labels = Array.from(new Set([
+      ...Object.keys(centre.lab_capabilities || {}),
+      ...(course.min_lab_req || []),
+      ...Object.keys(centre.skill_levels || {}),
+      ...(course.skill_prereqs || []),
+    ]));
+    const centreData = labels.map(l => centre.lab_capabilities[l] || centre.skill_levels[l] || 0);
+    const courseData = labels.map(l => (course.min_lab_req.includes(l) || course.skill_prereqs.includes(l)) ? 1 : 0);
+
+    const chart = new Chart(canvasRef.current, {
+      type: 'radar',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: 'Centre',
+            data: centreData,
+            backgroundColor: 'rgba(59,130,246,0.2)',
+            borderColor: 'rgb(59,130,246)',
+          },
+          {
+            label: 'Course',
+            data: courseData,
+            backgroundColor: 'rgba(16,185,129,0.2)',
+            borderColor: 'rgb(16,185,129)',
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        scales: { r: { beginAtZero: true } },
+      },
+    });
+    return () => chart.destroy();
+  }, [centre, course]);
+  return <canvas ref={canvasRef} className="w-full h-64"></canvas>;
+}
+
+function Dashboard() {
+  const [centreId, setCentreId] = useState(1);
+  const [data, setData] = useState({ centre: { lab_capabilities: {}, skill_levels: {} }, recommendations: [] });
+  const [modeFilter, setModeFilter] = useState({ online: true, onsite: true, hybrid: true });
+  const [minScore, setMinScore] = useState(0);
+  const [open, setOpen] = useState(null);
+
+  const fetchData = () => {
+    fetch(`/recommend/${centreId}?top_n=20`)
+      .then(res => res.json())
+      .then(setData);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [centreId]);
+
+  const filtered = data.recommendations.filter(c => modeFilter[c.delivery_mode] && c.score >= minScore);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2 items-center">
+        <label>Centre ID:</label>
+        <input className="border p-1" value={centreId} onChange={e => setCentreId(e.target.value)} />
+        <button className="bg-blue-500 text-white px-2 py-1" onClick={fetchData}>Load</button>
+      </div>
+      <div className="flex space-x-4">
+        {Object.keys(modeFilter).map(mode => (
+          <label key={mode} className="flex items-center space-x-1">
+            <input type="checkbox" checked={modeFilter[mode]} onChange={e => setModeFilter({ ...modeFilter, [mode]: e.target.checked })} />
+            <span>{mode}</span>
+          </label>
+        ))}
+        <label className="flex items-center space-x-1">
+          <span>Min score</span>
+          <input type="number" className="border p-1 w-20" value={minScore} step="0.1" onChange={e => setMinScore(parseFloat(e.target.value) || 0)} />
+        </label>
+      </div>
+      {filtered.map((course, idx) => (
+        <div key={course.id} className="bg-white p-4 rounded shadow" onClick={() => setOpen(open === idx ? null : idx)}>
+          <div className="flex justify-between items-center">
+            <h3 className="text-xl font-semibold">{course.title}</h3>
+            <span className="text-sm">{(course.score * 100).toFixed(1)}%</span>
+          </div>
+          <div className="w-full bg-gray-200 rounded h-2 mt-2">
+            <div className="bg-blue-500 h-2 rounded" style={{ width: `${course.score * 100}%` }}></div>
+          </div>
+          {open === idx && (
+            <div className="mt-4">
+              <RadarChart centre={data.centre} course={course} />
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<Dashboard />);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Training Course Recommendations</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root" class="p-4"></div>
+    <script type="text/babel" src="dashboard.js"></script>
+  </body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,12 @@ A comprehensive Know Your Customer (KYC) verification system specifically design
 - Model Context Protocol (MCP) wrapper for AI integrations
 - REST onboarding API with MCP wrapper support
 
+📚 **Training Course Recommendations**
+- PostgreSQL & SQLAlchemy models for centres, labs, staff skills and courses
+- ETL pipeline with scikit-learn producing centre and course feature matrices
+- FastAPI service returning recommended courses for a centre
+- React/Tailwind dashboard visualising similarity scores and capability radar charts
+
 📊 **Risk Assessment**
 - Automated risk scoring
 - Educational-specific compliance checks
@@ -64,6 +70,29 @@ The Railway deployment now provisions a **PostgreSQL** service for storing user
 accounts and provider applications. The FastAPI application connects to this
 database using SQLAlchemy. Dataclasses in `app/models.py` define the schema for
 `user_accounts` and `applications` tables, which support full CRUD operations.
+
+## Course Recommendation Engine
+
+The repository now contains a small training course recommendation prototype.
+
+```bash
+# rebuild feature matrices via the main app
+curl -X POST http://localhost:8000/build-recommendations
+
+# start the recommendation API (included in main app)
+uvicorn app.main:app --reload
+
+# open the demo dashboard (served statically)
+# e.g. using a simple file server
+python -m http.server --directory frontend 8001
+```
+
+Navigate to `http://localhost:8001` and enter a centre ID to view recommended
+courses. Results can be filtered by delivery mode and minimum similarity score,
+with radar charts showing how centre capabilities compare to course
+requirements.
+The centre submission form invokes `POST /build-recommendations` to generate
+the latest feature matrices before requesting recommendations.
 
 ### Example: Qualification Search
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,7 @@ httpx==0.26.0
 reportlab==4.0.5
 openai>=1.3.5
 authlib==1.2.1
+numpy==1.26.2
+scikit-learn==1.3.2
+joblib==1.3.2
 

--- a/templates/centre_submission_form.html
+++ b/templates/centre_submission_form.html
@@ -125,6 +125,12 @@
         </div>
     </form>
 </div>
+{% if recommend_available %}
+<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8" id="recommendation-section">
+    <h3 class="text-xl font-semibold text-gray-900 mb-4">Recommended Courses</h3>
+    <button type="button" id="recommend-btn" class="bg-green-600 text-white px-4 py-2 rounded-md mb-4">Get Recommendations</button>
+    <div id="recommendations" class="space-y-2"></div>
+</div>
 
 <script>
 // Disable all form fields until verification ID is validated
@@ -186,5 +192,41 @@ verificationInput.addEventListener('input', function(e) {
         }
     }, 500);
 });
+
+const centreId = {{ centre_id | tojson }};
+const recommendBtn = document.getElementById('recommend-btn');
+const recContainer = document.getElementById('recommendations');
+if (recommendBtn) {
+    if (centreId === null) {
+        recommendBtn.disabled = true;
+        recommendBtn.textContent = 'Centre unavailable';
+    } else {
+        recommendBtn.addEventListener('click', async () => {
+            recommendBtn.disabled = true;
+            recContainer.innerHTML = '';
+            recommendBtn.textContent = 'Preparing...';
+            try {
+                await fetch('/build-recommendations', {method: 'POST'});
+                recommendBtn.textContent = 'Loading...';
+                const resp = await fetch(`/recommend/${centreId}`);
+                const data = await resp.json();
+                recContainer.innerHTML = '';
+                data.recommendations.forEach(r => {
+                    const card = document.createElement('div');
+                    card.className = 'border p-4 rounded-md';
+                    card.innerHTML = `<div class="font-medium">${r.title}</div>` +
+                        `<div class=\"text-sm text-gray-600\">Score: ${(r.score * 100).toFixed(1)}%</div>`;
+                    recContainer.appendChild(card);
+                });
+            } catch (_) {
+                recContainer.innerHTML = '<div class="text-red-600">Failed to load recommendations</div>';
+            } finally {
+                recommendBtn.disabled = false;
+                recommendBtn.textContent = 'Get Recommendations';
+            }
+        });
+    }
+}
 </script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add PostgreSQL models and ETL pipeline for centre/course features
- expose FastAPI endpoint recommending courses based on cosine similarity
- build React/Tailwind dashboard with radar charts for capabilities
- hook course recommendations into centre submission page
- allow centre submission page to trigger ETL and mount recommender API
- hide recommendation UI when service isn't configured to avoid routing issues

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68919b033e84832c8defd3b832e29ea2