### PR TITLE
Add build-recommendations endpoint and tests

### DIFF
--- a/tests/test_build_recommendations.py
+++ b/tests/test_build_recommendations.py
@@ -1,0 +1,48 @@
+import types
+import sys
+import importlib
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# Provide a lightweight recommendation module so the main app can import it
+dummy_module = types.ModuleType("backend.recommend")
+dummy_module.app = FastAPI()
+
+
+@dummy_module.app.get("/recommend/{centre_id}")
+def _unused_route(centre_id: int, top_n: int = 10):
+    """Placeholder route not used in tests but required for FastAPI mount."""
+    return {"centre": {"id": centre_id}, "recommendations": []}
+
+
+def recommend(centre_id: int, top_n: int = 10):
+    return {
+        "centre": {"id": centre_id},
+        "recommendations": [{"id": 1, "title": "Dummy", "score": 0.5}],
+    }
+
+
+dummy_module.recommend = recommend
+sys.modules["backend.recommend"] = dummy_module
+
+
+from app.main import app  # noqa: E402  # import after dummy module injection
+import app.main as main_module  # noqa: E402
+
+
+def test_build_recommendations(monkeypatch):
+    """Ensure the build-recommendations endpoint returns recommendation data."""
+
+    # Avoid running the actual ETL and reloading during tests
+    monkeypatch.setattr(main_module, "run_etl", lambda: None)
+    monkeypatch.setattr(importlib, "reload", lambda module: module)
+
+    client = TestClient(app)
+    resp = client.post("/build-recommendations", json={"centre_id": 1, "top_n": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["centre"]["id"] == 1
+    assert len(data["recommendations"]) == 1
+


### PR DESCRIPTION
## Summary
- extend API with `/build-recommendations` POST route to rebuild feature data and return course recommendations
- add request model for recommendation parameters and return JSON results
- add tests ensuring the endpoint returns a recommendation list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920263cbfc832c80a17e4b2c5f14d0