### PR TITLE
Improve recommendation availability handling

### DIFF
--- a/templates/centre_submission_form.html
+++ b/templates/centre_submission_form.html
@@ -10,12 +10,6 @@
         </p>
     </div>
 
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8" id="recommendation-section">
-    <h3 class="text-xl font-semibold text-gray-900 mb-4">Recommended Courses</h3>
-    <button type="button" id="recommend-btn" class="bg-green-600 text-white px-4 py-2 rounded-md mb-4">Get Recommendations</button>
-    <div id="recommendations" class="space-y-2"></div>
-    </div>
-
     <form method="POST" action="/centre-submission" class="bg-white rounded-2xl shadow-lg p-10 space-y-10">
         <!-- Verification Section -->
         <section class="border-b border-gray-200 pb-8">
@@ -211,20 +205,31 @@ if (recommendBtn) {
             recContainer.innerHTML = '';
             recommendBtn.textContent = 'Preparing...';
             try {
-                await fetch('/build-recommendations', {method: 'POST'});
+                const buildResp = await fetch('/build-recommendations', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({centre_id: centreId})
+                });
+                const buildData = await buildResp.json();
+                if (!buildResp.ok) {
+                    throw new Error(buildData.detail || 'Failed to build recommendations');
+                }
                 recommendBtn.textContent = 'Loading...';
                 const resp = await fetch(`/recommend/${centreId}`);
                 const data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(data.detail || 'Failed to load recommendations');
+                }
                 recContainer.innerHTML = '';
                 data.recommendations.forEach(r => {
                     const card = document.createElement('div');
                     card.className = 'border p-4 rounded-md';
                     card.innerHTML = `<div class="font-medium">${r.title}</div>` +
-                        `<div class=\"text-sm text-gray-600\">Score: ${(r.score * 100).toFixed(1)}%</div>`;
+                        `<div class="text-sm text-gray-600">Score: ${(r.score * 100).toFixed(1)}%</div>`;
                     recContainer.appendChild(card);
                 });
-            } catch (_) {
-                recContainer.innerHTML = '<div class="text-red-600">Failed to load recommendations</div>';
+            } catch (err) {
+                recContainer.innerHTML = `<div class="text-red-600">${err.message}</div>`;
             } finally {
                 recommendBtn.disabled = false;
                 recommendBtn.textContent = 'Get Recommendations';


### PR DESCRIPTION
## Summary
- Track recommendation engine availability with `RECOMMEND_AVAILABLE` and warn at startup when disabled
- Harden `build-recommendations` with ETL error logging and dynamic router reloading
- Update centre submission form to send centre ID, surface backend errors, and hide button when recommendations are unavailable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892094107ec832cb4e3303e9bb1dcd4