### PR TITLE
Handle empty centre ratings in ETL

### DIFF
--- a/backend/etl.py
+++ b/backend/etl.py
@@ -81,7 +81,20 @@ def run_etl(output_dir: str = None):
         else:
             delivery_features = 0
 
-        rating_scaler = StandardScaler().fit(np.array(centre_ratings).reshape(-1, 1))
+        if centre_ratings:
+            rating_scaler = StandardScaler().fit(
+                np.array(centre_ratings).reshape(-1, 1)
+            )
+            centre_rating_matrix = csr_matrix(
+                rating_scaler.transform(
+                    np.array(centre_ratings).reshape(-1, 1)
+                )
+            )
+        else:
+            # No centres in the database. Fit scaler on a default value and
+            # create an empty rating matrix to keep feature dimensions
+            rating_scaler = StandardScaler().fit(np.array([[0.0]]))
+            centre_rating_matrix = csr_matrix((0, 1))
 
         centre_lab_matrix = (
             lab_vec.transform(centre_lab_dicts)
@@ -93,7 +106,6 @@ def run_etl(output_dir: str = None):
             if centre_skill_dicts
             else csr_matrix((0, len(skill_vec.get_feature_names_out())))
         )
-        centre_rating_matrix = rating_scaler.transform(np.array(centre_ratings).reshape(-1, 1))
         centre_delivery_zeros = csr_matrix(
             np.zeros((centre_lab_matrix.shape[0], delivery_features))
         )

--- a/tests/test_etl_empty_centres.py
+++ b/tests/test_etl_empty_centres.py
@@ -1,0 +1,49 @@
+import types
+import joblib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_run_etl_handles_no_centres(tmp_path, monkeypatch):
+    """run_etl should not fail when there are no centres in the database."""
+    import backend.etl as etl
+
+    course = types.SimpleNamespace(
+        id=1,
+        title="Sample Course",
+        delivery_mode="online",
+        min_lab_req=[],
+        skill_prereqs=[],
+        online_content_ok=True,
+    )
+
+    class FakeQuery:
+        def __init__(self, data):
+            self.data = data
+
+        def options(self, *args, **kwargs):
+            return self
+
+        def all(self):
+            return self.data
+
+    class FakeSession:
+        def query(self, model):
+            if model is etl.Centre:
+                return FakeQuery([])
+            if model is etl.Course:
+                return FakeQuery([course])
+            return FakeQuery([])
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(etl, "SessionLocal", lambda: FakeSession())
+    monkeypatch.setattr(etl, "init_db", lambda: None)
+
+    etl.run_etl(output_dir=str(tmp_path))
+
+    centre_meta = joblib.load(tmp_path / "centre_metadata.pkl")
+    assert centre_meta == []


### PR DESCRIPTION
## Summary
- Prevent StandardScaler from failing when no centres are present by fitting a default scaler and returning an empty rating matrix
- Add regression test ensuring `run_etl` succeeds with an empty centres dataset

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689246bd256c832c96e249f4662c454f