### PR TITLE
Add database seed script for sample data

### DIFF
--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -1,0 +1,78 @@
+from .database import SessionLocal, init_db
+from .models import Centre, CentreLab, CentreStaffSkill, Course, CourseTag
+
+
+def seed():
+    """Populate the database with sample centres and courses."""
+    init_db()
+    db = SessionLocal()
+    try:
+        if db.query(Centre).first():
+            print("Database already contains data; skipping seed.")
+            return
+
+        centre1 = Centre(
+            name="Sample College",
+            location="London",
+            capacity=500,
+            online_rating=4.5,
+        )
+        centre1.labs = [
+            CentreLab(lab_type="IT Lab", capability=0.9),
+        ]
+        centre1.skills = [
+            CentreStaffSkill(skill="Python", level=0.8),
+        ]
+
+        centre2 = Centre(
+            name="City Training",
+            location="Manchester",
+            capacity=300,
+            online_rating=4.0,
+        )
+        centre2.labs = [
+            CentreLab(lab_type="Data Lab", capability=0.7),
+        ]
+        centre2.skills = [
+            CentreStaffSkill(skill="Data Analysis", level=0.6),
+        ]
+
+        course1 = Course(
+            title="Intro to Python",
+            description="Learn the basics of Python programming",
+            delivery_mode="online",
+            min_lab_req=["IT Lab"],
+            skill_prereqs=["Python"],
+            online_content_ok=True,
+        )
+        course1.tags = [
+            CourseTag(tag="programming"),
+            CourseTag(tag="python"),
+        ]
+
+        course2 = Course(
+            title="Data Science 101",
+            description="Foundations of data science",
+            delivery_mode="onsite",
+            min_lab_req=["Data Lab"],
+            skill_prereqs=["Python"],
+            online_content_ok=False,
+        )
+        course2.tags = [
+            CourseTag(tag="data"),
+            CourseTag(tag="science"),
+        ]
+
+        db.add_all([centre1, centre2, course1, course2])
+        db.commit()
+        print("Seed data inserted.")
+    finally:
+        db.close()
+
+
+def main():
+    seed()
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,9 @@ uvicorn app.main:app --reload
 # create tables locally
 python -c "from backend.database import init_db; init_db()"
 
+# populate with example centres and courses before running ETL/recommendations
+python -m backend.seed_data
+
 ```
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/your-template-id)
 
@@ -74,6 +77,13 @@ database using SQLAlchemy. Dataclasses in `app/models.py` define the schema for
 ## Course Recommendation Engine
 
 The repository now contains a small training course recommendation prototype.
+
+Before generating feature matrices or running the recommendation API, seed the
+database with sample data:
+
+```bash
+python -m backend.seed_data
+```
 
 ```bash
 # rebuild feature matrices via the main app


### PR DESCRIPTION
## Summary
- add `backend/seed_data` module to populate example centres, labs, skills, courses and tags
- document how to run the seed script before building feature matrices or recommendations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68925641ca34832c9d8602cffa0ac7d4