### PR TITLE
Fix recommendations path to avoid 404

### DIFF
--- a/templates/centre_submission_form.html
+++ b/templates/centre_submission_form.html
@@ -211,7 +211,8 @@ if (recommendBtn) {
                     const buildData = await buildResp.json();
                     throw new Error(buildData.detail || 'Failed to build recommendations');
                 }
-                window.open(`/recommendations?centre_id=${centreId}`, '_blank');
+                // Include trailing slash so the static frontend is served correctly
+                window.open(`/recommendations/?centre_id=${centreId}`, '_blank');
             } catch (err) {
                 alert(err.message);
             } finally {


### PR DESCRIPTION
## Summary
- Ensure recommendations frontend is requested with a trailing slash so static files are served

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68926bb61454832c838f7cb7bbf17022