### PR TITLE
Add risk scoring and visualization to recommendations dashboard

### DIFF
--- a/backend/etl.py
+++ b/backend/etl.py
@@ -48,6 +48,17 @@ def run_etl(output_dir: str = None):
                     "labs": list(lab_dict.keys()),
                     "skills": list(skill_dict.keys()),
                     "online_rating": rating,
+                    "years_operating": getattr(c, "years_operating", 0),
+                    "offers_similar_courses": getattr(
+                        c, "offers_similar_courses", False
+                    ),
+                    "standards_verification": getattr(
+                        c, "standards_verification", "unknown"
+                    ),
+                    "years_known_ao": getattr(c, "years_known_ao", 0),
+                    "late_payment_history": getattr(
+                        c, "late_payment_history", False
+                    ),
                 }
             )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -11,6 +11,11 @@ class Centre(Base):
     location = Column(String)
     capacity = Column(Integer)
     online_rating = Column(Float)
+    years_operating = Column(Integer, default=0)
+    offers_similar_courses = Column(Boolean, default=False)
+    standards_verification = Column(String, default="unknown")
+    years_known_ao = Column(Integer, default=0)
+    late_payment_history = Column(Boolean, default=False)
 
     labs = relationship("CentreLab", back_populates="centre", cascade="all, delete-orphan")
     skills = relationship("CentreStaffSkill", back_populates="centre", cascade="all, delete-orphan")

--- a/backend/recommend.py
+++ b/backend/recommend.py
@@ -7,6 +7,8 @@ import numpy as np
 from fastapi import FastAPI, HTTPException
 from sklearn.metrics.pairwise import cosine_similarity
 
+from .risk import calculate_risk_score, classify_partner
+
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
 centre_features = joblib.load(os.path.join(DATA_DIR, "centre_feature_matrix.pkl"))
@@ -28,6 +30,8 @@ def recommend(centre_id: int, top_n: int = 10):
     centre_info = centre_meta[idx]
     owned_labs = set(centre_info["labs"])
     rating = centre_info["online_rating"]
+    risk_score = calculate_risk_score(centre_info)
+    partner_tier = classify_partner(risk_score)
 
     sims = cosine_similarity(centre_vec, course_features)[0]
     results: List[dict] = []
@@ -53,6 +57,8 @@ def recommend(centre_id: int, top_n: int = 10):
             "id": centre_id,
             "lab_capabilities": centre_info["lab_capabilities"],
             "skill_levels": centre_info["skill_levels"],
+            "risk_score": risk_score,
+            "partner_tier": partner_tier,
         },
         "recommendations": results[:top_n],
     }

--- a/backend/risk.py
+++ b/backend/risk.py
@@ -1,0 +1,37 @@
+from typing import Dict
+
+STANDARD_SCORES = {
+    "good": 1.0,
+    "poor": 0.0,
+    "unknown": 0.5,
+}
+
+
+def calculate_risk_score(data: Dict) -> float:
+    """Calculate a 0-10 partnership risk score based on centre features."""
+    years_operating = min(data.get("years_operating", 0), 20) / 20
+    similar = 1.0 if data.get("offers_similar_courses") else 0.0
+    standards = STANDARD_SCORES.get(
+        str(data.get("standards_verification", "unknown")).lower(), 0.5
+    )
+    years_known = min(data.get("years_known_ao", 0), 20) / 20
+    payment = 0.0 if data.get("late_payment_history") else 1.0
+
+    score = (
+        0.25 * years_operating
+        + 0.15 * similar
+        + 0.25 * standards
+        + 0.20 * years_known
+        + 0.15 * payment
+    ) * 10
+    return round(score, 2)
+
+
+def classify_partner(score: float) -> str:
+    if score >= 10:
+        return "Strategic Partner"
+    if score >= 7:
+        return "Sector Partner"
+    if score >= 3:
+        return "Established Partner"
+    return "Developing Partner"

--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -16,6 +16,11 @@ def seed():
             location="London",
             capacity=500,
             online_rating=4.5,
+            years_operating=5,
+            offers_similar_courses=True,
+            standards_verification="good",
+            years_known_ao=3,
+            late_payment_history=False,
         )
         centre1.labs = [
             CentreLab(lab_type="IT Lab", capability=0.9),
@@ -29,6 +34,11 @@ def seed():
             location="Manchester",
             capacity=300,
             online_rating=4.0,
+            years_operating=2,
+            offers_similar_courses=False,
+            standards_verification="poor",
+            years_known_ao=1,
+            late_payment_history=True,
         )
         centre2.labs = [
             CentreLab(lab_type="Data Lab", capability=0.7),

--- a/frontend/Dashboard.js
+++ b/frontend/Dashboard.js
@@ -62,7 +62,7 @@ function RadarChart({ centre, course }) {
 function Dashboard() {
   const [centreId, setCentreId] = useState(getInitialCentreId());
   const [data, setData] = useState({
-    centre: { lab_capabilities: {}, skill_levels: {} },
+    centre: { lab_capabilities: {}, skill_levels: {}, risk_score: 0, partner_tier: "" },
     recommendations: [],
   });
   const [error, setError] = useState(null);
@@ -84,7 +84,7 @@ function Dashboard() {
     } catch (err) {
       setError(err.message);
       setData({
-        centre: { lab_capabilities: {}, skill_levels: {} },
+        centre: { lab_capabilities: {}, skill_levels: {}, risk_score: 0, partner_tier: "" },
         recommendations: [],
       });
     }
@@ -114,6 +114,22 @@ function Dashboard() {
         >
           Load
         </button>
+      </div>
+      <div className="bg-white p-4 rounded shadow">
+        <div className="flex justify-between text-sm mb-1">
+          <span>Risk Score</span>
+          <span>{data.centre.partner_tier} ({data.centre.risk_score.toFixed(1)})</span>
+        </div>
+        <div className="w-full bg-gray-200 rounded h-4 relative">
+          <div
+            className="bg-green-500 h-4 rounded"
+            style={{ width: `${(data.centre.risk_score / 10) * 100}%` }}
+          ></div>
+          <div className="absolute inset-0 flex justify-between text-xs px-1">
+            <span>0</span>
+            <span>10</span>
+          </div>
+        </div>
       </div>
       <div className="flex space-x-4">
         {Object.keys(modeFilter).map((mode) => (

--- a/tests/test_risk_algorithm.py
+++ b/tests/test_risk_algorithm.py
@@ -1,0 +1,14 @@
+from backend.risk import calculate_risk_score, classify_partner
+
+
+def test_risk_scoring_and_classification():
+    features = {
+        "years_operating": 10,
+        "offers_similar_courses": True,
+        "standards_verification": "good",
+        "years_known_ao": 8,
+        "late_payment_history": False,
+    }
+    score = calculate_risk_score(features)
+    assert score == 7.55
+    assert classify_partner(score) == "Sector Partner"


### PR DESCRIPTION
## Summary
- extend centre model with risk-related fields and seed sample data
- implement weighted risk scoring algorithm with partner tier classification
- expose risk score via recommendation API and render progress bar in dashboard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893062a28c8832cb1afd2fdefe8416f