### PR TITLE
docs: document course recommendation design

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,23 @@ requirements.
 The centre submission form invokes `POST /build-recommendations` to generate
 the latest feature matrices before requesting recommendations.
 
+### How recommendations work
+
+The recommendation engine models each centre and course using features drawn
+from the relational database. `centres` link to their available labs and staff
+skills via the `centre_labs` and `centre_staff_skills` tables, while courses
+list required labs and prerequisite skills in `courses` and `course_tags`.
+During ETL these attributes are vectorised with scikit‑learn's
+`DictVectorizer`, `OneHotEncoder` and `StandardScaler` to build comparable
+feature matrices for centres and courses. When a recommendation is requested,
+the API computes cosine similarity between the centre's feature vector and all
+course vectors, filtering out options that lack required labs or have online
+content unsuitable for low‑rated centres. Results are sorted by similarity and
+annotated with a risk score and partner tier. The React dashboard fetches this
+data and overlays centre capabilities against course requirements using a
+Chart.js radar chart, allowing users to explore how well each course matches a
+particular centre's resources.
+
 ### Example: Qualification Search
 
 Use the built-in client to retrieve Pearson Education qualifications by title.


### PR DESCRIPTION
## Summary
- describe how centres and courses are matched via database tables and feature encoding
- outline cosine-similarity matching, risk scoring, and dashboard visualisation

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: recommendations frontend 404)*

------
https://chatgpt.com/codex/tasks/task_e_6893814aa6f8832ca9e3f7a88dd7bfdc