### PR TITLE
feat: analyse training needs and suggest courses

### DIFF
--- a/templates/centre_submission_form.html
+++ b/templates/centre_submission_form.html
@@ -10,6 +10,10 @@
         </p>
     </div>
 
+    <div class="mb-6">
+        <a href="/tna" class="text-sm text-blue-600 hover:underline">Upload Training Needs Analysis</a>
+    </div>
+
     {% if recommend_available %}
     <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8" id="recommendation-section">
         <h3 class="text-xl font-semibold text-gray-900 mb-4">Recommended Courses</h3>

--- a/templates/tna_upload.html
+++ b/templates/tna_upload.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Training Needs Analysis{% endblock %}
+{% block content %}
+<div class="max-w-3xl mx-auto px-4 py-12">
+  <h2 class="text-2xl font-bold mb-6">Upload Training Needs Analysis</h2>
+  <form method="post" enctype="multipart/form-data" class="mb-6">
+    <input type="file" name="file" required class="border rounded px-3 py-2"/>
+    <button type="submit" class="ml-2 bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
+  </form>
+  {% if uploaded %}
+    <p class="mb-4 text-sm text-gray-600">Uploaded {{ filename }}. Suggested courses:</p>
+  {% endif %}
+  {% if suggestions %}
+    <ul class="list-disc pl-5 space-y-2">
+      {% for course in suggestions %}
+        <li>{{ course.title }} ({{ (course.score * 100)|round(0) }}% match)</li>
+      {% endfor %}
+    </ul>
+  {% elif uploaded %}
+    <p>No matching courses found.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_tna_upload.py
+++ b/tests/test_tna_upload.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.main as main_module  # noqa: E402
+from app.main import app  # noqa: E402
+
+
+def test_tna_upload_suggests_courses(monkeypatch):
+    def fake_suggest(text: str):
+        return [{"id": 1, "title": "Python Basics", "score": 0.9}]
+
+    monkeypatch.setattr(main_module, "suggest_courses_from_text", fake_suggest)
+    client = TestClient(app)
+    client.post("/login", data={"username": "centre1", "password": "centrepass"})
+    tna_text = "Need training in Python programming."
+    resp = client.post("/tna", files={"file": ("tna.txt", tna_text.encode())})
+    assert resp.status_code == 200
+    assert "Python Basics" in resp.text


### PR DESCRIPTION
## Summary
- add training needs analysis upload page
- fuzzy match analysis text to existing courses and suggest best fits
- expose feature from qualification selection page

## Testing
- `DATABASE_URL=sqlite:///test.db pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894baa081c4832c8703e5eef10a85be