### PR TITLE
Highlight pre-approved course matches on recommendations dashboard

### DIFF
--- a/app/static/js/Dashboard.js
+++ b/app/static/js/Dashboard.js
@@ -233,7 +233,14 @@ function Dashboard() {
         >
           <div className="flex justify-between items-center">
             <h3 className="text-xl font-semibold">{course.title}</h3>
-            <span className="text-sm">{(course.score * 100).toFixed(1)}%</span>
+            <div className="flex items-center space-x-2">
+              <span className="text-sm">{(course.score * 100).toFixed(1)}%</span>
+              {course.score > 0.45 && (
+                <span className="text-xs bg-green-500 text-white px-2 py-1 rounded">
+                  Pre-approved
+                </span>
+              )}
+            </div>
           </div>
           <div className="w-full bg-gray-200 rounded h-2 mt-2">
             <div

--- a/frontend/Dashboard.js
+++ b/frontend/Dashboard.js
@@ -233,7 +233,14 @@ function Dashboard() {
         >
           <div className="flex justify-between items-center">
             <h3 className="text-xl font-semibold">{course.title}</h3>
-            <span className="text-sm">{(course.score * 100).toFixed(1)}%</span>
+            <div className="flex items-center space-x-2">
+              <span className="text-sm">{(course.score * 100).toFixed(1)}%</span>
+              {course.score > 0.45 && (
+                <span className="text-xs bg-green-500 text-white px-2 py-1 rounded">
+                  Pre-approved
+                </span>
+              )}
+            </div>
           </div>
           <div className="w-full bg-gray-200 rounded h-2 mt-2">
             <div

--- a/templates/Dashboard.js
+++ b/templates/Dashboard.js
@@ -163,7 +163,14 @@ function Dashboard() {
         >
           <div className="flex justify-between items-center">
             <h3 className="text-xl font-semibold">{course.title}</h3>
-            <span className="text-sm">{(course.score * 100).toFixed(1)}%</span>
+            <div className="flex items-center space-x-2">
+              <span className="text-sm">{(course.score * 100).toFixed(1)}%</span>
+              {course.score > 0.45 && (
+                <span className="text-xs bg-green-500 text-white px-2 py-1 rounded">
+                  Pre-approved
+                </span>
+              )}
+            </div>
           </div>
           <div className="w-full bg-gray-200 rounded h-2 mt-2">
             <div

--- a/tests/test_recommendations_frontend.py
+++ b/tests/test_recommendations_frontend.py
@@ -14,3 +14,4 @@ def test_dashboard_js_served():
     resp = client.get("/recommendations/Dashboard.js")
     assert resp.status_code == 200
     assert "getInitialCentreId" in resp.text
+    assert "Pre-approved" in resp.text


### PR DESCRIPTION
## Summary
- show "Pre-approved" badge when a recommended course scores above 45%
- add regression test to ensure the badge text is present in served Dashboard.js

## Testing
- `pytest -q` *(fails: could not translate host name "postgres.railway.internal" to address: Name or service not known)*
- `PYTHONPATH=. DATABASE_URL=sqlite:// pytest tests/test_recommendations_frontend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b27b44080832c8482688b1ea89994