### PR TITLE
Add LMS/MIS integration hub with CSV upload and automated learner-qualification assessment

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,8 @@ from pydantic import BaseModel
 from contextlib import asynccontextmanager
 import os
 import base64
+import csv
+import io
 from typing import Dict, List, Optional
 from datetime import datetime
 import json
@@ -99,6 +101,8 @@ providers_db = []
 applications_db: List[Dict] = []
 centre_submissions: List[CentreSubmission] = []
 processing_queue = {}
+lms_mis_integrations: Dict[str, Dict] = {}
+lms_mis_assessment_runs: Dict[str, List[Dict]] = {}
 
 # Per-user document storage metadata
 documents_storage: Dict[str, List[Dict]] = {}
@@ -739,6 +743,57 @@ def suggest_courses_from_text(text: str) -> List[Dict[str, float]]:
         session.close()
 
 
+def _normalise_qualification(value: Optional[str]) -> str:
+    return (value or "").strip().lower()
+
+
+def get_approved_qualifications_for_user(user: Dict) -> Dict[str, set]:
+    """Build a set of approved qualification identifiers and titles for a centre."""
+    approved_ids = set()
+    approved_titles = set()
+
+    for application in applications_db:
+        if str(application.get("status", "")).strip().lower() == "approved":
+            approved_ids.add(_normalise_qualification(application.get("qualification_number")))
+            approved_titles.add(_normalise_qualification(application.get("qualification_title")))
+
+    # Include any onboarded qualifications for approved providers
+    for provider in providers_db:
+        if str(provider.get("status", "")).strip().lower() == "approved":
+            for qualification in provider.get("qualifications_offered", []):
+                approved_titles.add(_normalise_qualification(qualification))
+
+    approved_ids.discard("")
+    approved_titles.discard("")
+    return {"ids": approved_ids, "titles": approved_titles}
+
+
+def assess_lms_mis_rows(rows: List[Dict[str, str]], approved: Dict[str, set]) -> List[Dict]:
+    """Assess uploaded learner records against approved centre qualifications."""
+    assessed_rows = []
+    for row in rows:
+        qualification_id = _normalise_qualification(row.get("qualification_id"))
+        qualification_title = _normalise_qualification(row.get("qualification_title"))
+        is_approved = (
+            qualification_id in approved["ids"] if qualification_id else False
+        ) or (
+            qualification_title in approved["titles"] if qualification_title else False
+        )
+        assessed_rows.append(
+            {
+                "learner_id": (row.get("learner_id") or "").strip(),
+                "learner_name": (row.get("learner_name") or "").strip(),
+                "qualification_id": row.get("qualification_id"),
+                "qualification_title": row.get("qualification_title"),
+                "registration_status": row.get("registration_status"),
+                "assessment_result": (
+                    "eligible_for_delivery" if is_approved else "not_approved_for_centre"
+                ),
+            }
+        )
+    return assessed_rows
+
+
 @app.get("/tna", response_class=HTMLResponse)
 async def tna_form(request: Request):
     """Display Training Needs Analysis upload form."""
@@ -746,6 +801,101 @@ async def tna_form(request: Request):
     if not user:
         return RedirectResponse("/login", status_code=302)
     return templates.TemplateResponse("tna_upload.html", {"request": request, "suggestions": None})
+
+
+@app.get("/integrations/lms-mis", response_class=HTMLResponse)
+async def lms_mis_integration_page(request: Request):
+    """Configure LMS/MIS integration and assess learner records."""
+    user = get_current_user(request)
+    if not user:
+        return RedirectResponse("/login", status_code=302)
+
+    centre_key = user["name"]
+    integration = lms_mis_integrations.get(centre_key)
+    latest_run = (lms_mis_assessment_runs.get(centre_key) or [None])[-1]
+    approved = get_approved_qualifications_for_user(user)
+
+    return templates.TemplateResponse(
+        "lms_mis_integration.html",
+        {
+            "request": request,
+            "user": user,
+            "integration": integration,
+            "latest_run": latest_run,
+            "approved_count": len(approved["ids"]) + len(approved["titles"]),
+        },
+    )
+
+
+@app.post("/integrations/lms-mis/configure", response_class=HTMLResponse)
+async def configure_lms_mis_integration(
+    request: Request,
+    system_type: str = Form(...),
+    provider_name: str = Form(...),
+    endpoint_url: str = Form(...),
+    data_format: str = Form(...),
+    sync_frequency: str = Form(...),
+):
+    user = get_current_user(request)
+    if not user:
+        return RedirectResponse("/login", status_code=302)
+
+    centre_key = user["name"]
+    lms_mis_integrations[centre_key] = {
+        "system_type": system_type,
+        "provider_name": provider_name,
+        "endpoint_url": endpoint_url,
+        "data_format": data_format,
+        "sync_frequency": sync_frequency,
+        "configured_at": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+    }
+    return RedirectResponse("/integrations/lms-mis", status_code=303)
+
+
+@app.post("/integrations/lms-mis/upload", response_class=HTMLResponse)
+async def upload_lms_mis_data(request: Request, file: UploadFile = File(...)):
+    user = get_current_user(request)
+    if not user:
+        return RedirectResponse("/login", status_code=302)
+
+    if not file.filename or not file.filename.lower().endswith(".csv"):
+        raise HTTPException(status_code=400, detail="Please upload a CSV file.")
+
+    payload = await file.read()
+    try:
+        text_data = payload.decode("utf-8")
+    except UnicodeDecodeError:
+        text_data = payload.decode("latin-1")
+
+    reader = csv.DictReader(io.StringIO(text_data))
+    rows = [row for row in reader]
+    approved = get_approved_qualifications_for_user(user)
+    assessed_rows = assess_lms_mis_rows(rows, approved)
+
+    matched = sum(1 for r in assessed_rows if r["assessment_result"] == "eligible_for_delivery")
+    unmatched = len(assessed_rows) - matched
+    run_summary = {
+        "uploaded_filename": file.filename,
+        "uploaded_at": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+        "total_rows": len(assessed_rows),
+        "matched_rows": matched,
+        "unmatched_rows": unmatched,
+        "assessed_rows": assessed_rows[:50],
+    }
+    centre_key = user["name"]
+    lms_mis_assessment_runs.setdefault(centre_key, []).append(run_summary)
+
+    return templates.TemplateResponse(
+        "lms_mis_integration.html",
+        {
+            "request": request,
+            "user": user,
+            "integration": lms_mis_integrations.get(centre_key),
+            "latest_run": run_summary,
+            "approved_count": len(approved["ids"]) + len(approved["titles"]),
+            "upload_success": True,
+        },
+    )
 
 
 @app.post("/tna", response_class=HTMLResponse)

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,7 @@
                         <a href="/applications" class="text-gray-600 hover:text-indigo-600 px-3 py-2 text-sm font-medium transition">Qualification Approval</a>
                         <a href="/centre-submission" class="text-gray-600 hover:text-indigo-600 px-3 py-2 text-sm font-medium transition">Qualification Selection</a>                        
                         <a href="/documents" class="text-gray-600 hover:text-indigo-600 px-3 py-2 text-sm font-medium transition">Evidence</a>
+                        <a href="/integrations/lms-mis" class="text-gray-600 hover:text-indigo-600 px-3 py-2 text-sm font-medium transition">LMS/MIS Integration</a>
                         <a href="/verify-credential" class="text-gray-600 hover:text-indigo-600 px-3 py-2 text-sm font-medium transition">Verify a Centre</a>
                         <a href="/about" class="text-gray-600 hover:text-indigo-600 px-3 py-2 text-sm font-medium transition">About</a>
                         {% if request.session.get('user') %}

--- a/templates/lms_mis_integration.html
+++ b/templates/lms_mis_integration.html
@@ -1,0 +1,147 @@
+{% extends "base.html" %}
+
+{% block title %}LMS/MIS Integration | Certify3{% endblock %}
+
+{% block content %}
+<section class="max-w-6xl mx-auto py-8 space-y-6">
+    <div class="bg-white shadow rounded-xl p-6 border border-gray-100">
+        <h1 class="text-2xl font-semibold text-gray-900">LMS & MIS Integration Hub</h1>
+        <p class="text-gray-600 mt-2">
+            Connect your centre's LMS or MIS so learner records can be uploaded and automatically checked
+            against qualifications your centre is approved to deliver.
+        </p>
+        <div class="mt-4 grid md:grid-cols-3 gap-4 text-sm">
+            <div class="bg-indigo-50 rounded-lg p-4">
+                <p class="text-indigo-700 font-medium">Approved Qualifications Indexed</p>
+                <p class="text-2xl font-bold text-indigo-900 mt-1">{{ approved_count }}</p>
+            </div>
+            <div class="bg-green-50 rounded-lg p-4">
+                <p class="text-green-700 font-medium">Integration Status</p>
+                <p class="text-lg font-semibold text-green-900 mt-1">
+                    {% if integration %}Configured{% else %}Not Configured{% endif %}
+                </p>
+            </div>
+            <div class="bg-slate-50 rounded-lg p-4">
+                <p class="text-slate-700 font-medium">Latest Upload</p>
+                <p class="text-sm font-semibold text-slate-900 mt-1">
+                    {% if latest_run %}{{ latest_run.uploaded_filename }}{% else %}No uploads yet{% endif %}
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="grid lg:grid-cols-2 gap-6">
+        <div class="bg-white shadow rounded-xl p-6 border border-gray-100">
+            <h2 class="text-xl font-semibold text-gray-900 mb-4">1) Configure Integration</h2>
+            <form method="post" action="/integrations/lms-mis/configure" class="space-y-4">
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">System Type</label>
+                    <select name="system_type" class="w-full border rounded-lg px-3 py-2" required>
+                        <option value="LMS">LMS</option>
+                        <option value="MIS">MIS</option>
+                        <option value="Both">Both LMS + MIS</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Provider Name</label>
+                    <input name="provider_name" class="w-full border rounded-lg px-3 py-2" placeholder="e.g. Moodle, Canvas, ProSolution" required />
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Endpoint URL</label>
+                    <input name="endpoint_url" type="url" class="w-full border rounded-lg px-3 py-2" placeholder="https://your-system.example/api/students" required />
+                </div>
+                <div class="grid grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Data Format</label>
+                        <select name="data_format" class="w-full border rounded-lg px-3 py-2" required>
+                            <option value="CSV">CSV</option>
+                            <option value="JSON">JSON</option>
+                            <option value="XML">XML</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Sync Frequency</label>
+                        <select name="sync_frequency" class="w-full border rounded-lg px-3 py-2" required>
+                            <option value="Daily">Daily</option>
+                            <option value="Weekly">Weekly</option>
+                            <option value="Real-time">Real-time</option>
+                        </select>
+                    </div>
+                </div>
+                <button class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg font-medium">
+                    Save Integration
+                </button>
+            </form>
+
+            {% if integration %}
+            <div class="mt-6 p-4 rounded-lg border bg-gray-50 text-sm text-gray-700">
+                <p class="font-semibold text-gray-900 mb-1">Current Configuration</p>
+                <p><span class="font-medium">System:</span> {{ integration.system_type }} ({{ integration.provider_name }})</p>
+                <p><span class="font-medium">Endpoint:</span> {{ integration.endpoint_url }}</p>
+                <p><span class="font-medium">Format:</span> {{ integration.data_format }} | <span class="font-medium">Frequency:</span> {{ integration.sync_frequency }}</p>
+                <p><span class="font-medium">Configured:</span> {{ integration.configured_at }} UTC</p>
+            </div>
+            {% endif %}
+        </div>
+
+        <div class="bg-white shadow rounded-xl p-6 border border-gray-100">
+            <h2 class="text-xl font-semibold text-gray-900 mb-4">2) Upload Learner Data</h2>
+            <p class="text-sm text-gray-600 mb-3">
+                Upload a CSV with columns: <code>learner_id</code>, <code>learner_name</code>,
+                <code>qualification_id</code>, <code>qualification_title</code>, and <code>registration_status</code>.
+            </p>
+            <form method="post" action="/integrations/lms-mis/upload" enctype="multipart/form-data" class="space-y-4">
+                <input type="file" name="file" accept=".csv" class="w-full border rounded-lg px-3 py-2" required />
+                <button class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-lg font-medium">
+                    Upload & Assess
+                </button>
+            </form>
+
+            {% if upload_success %}
+            <p class="mt-4 text-sm text-emerald-700 font-medium">Upload completed and assessment generated.</p>
+            {% endif %}
+
+            {% if latest_run %}
+            <div class="mt-6 p-4 rounded-lg border bg-emerald-50 text-sm">
+                <p class="font-semibold text-emerald-900">Latest Assessment Summary</p>
+                <p class="text-emerald-800">{{ latest_run.total_rows }} learner records processed.</p>
+                <p class="text-emerald-800">{{ latest_run.matched_rows }} matched approved qualifications.</p>
+                <p class="text-emerald-800">{{ latest_run.unmatched_rows }} flagged as not approved for this centre.</p>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if latest_run and latest_run.assessed_rows %}
+    <div class="bg-white shadow rounded-xl p-6 border border-gray-100 overflow-x-auto">
+        <h3 class="text-lg font-semibold text-gray-900 mb-4">Learner Assessment Results (latest upload)</h3>
+        <table class="min-w-full text-sm">
+            <thead>
+                <tr class="text-left border-b">
+                    <th class="py-2 pr-4">Learner</th>
+                    <th class="py-2 pr-4">Qualification</th>
+                    <th class="py-2 pr-4">Registration Status</th>
+                    <th class="py-2 pr-4">Assessment</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in latest_run.assessed_rows %}
+                <tr class="border-b last:border-0">
+                    <td class="py-2 pr-4">{{ row.learner_name }}<br><span class="text-xs text-gray-500">{{ row.learner_id }}</span></td>
+                    <td class="py-2 pr-4">{{ row.qualification_title }}<br><span class="text-xs text-gray-500">{{ row.qualification_id }}</span></td>
+                    <td class="py-2 pr-4">{{ row.registration_status or "-" }}</td>
+                    <td class="py-2 pr-4">
+                        {% if row.assessment_result == "eligible_for_delivery" %}
+                        <span class="inline-flex bg-emerald-100 text-emerald-800 px-2 py-1 rounded-full text-xs font-medium">Eligible</span>
+                        {% else %}
+                        <span class="inline-flex bg-rose-100 text-rose-800 px-2 py-1 rounded-full text-xs font-medium">Not Approved</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+</section>
+{% endblock %}

--- a/tests/test_lms_mis_integration.py
+++ b/tests/test_lms_mis_integration.py
@@ -1,0 +1,56 @@
+import io
+
+from fastapi.testclient import TestClient
+
+from app.main import app, applications_db, lms_mis_assessment_runs, lms_mis_integrations
+
+
+def test_lms_mis_page_requires_authentication():
+    client = TestClient(app)
+    response = client.get("/integrations/lms-mis", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/login"
+
+
+def test_lms_mis_upload_assesses_learner_records_against_approved_qualifications():
+    client = TestClient(app)
+
+    login_response = client.post(
+        "/login",
+        data={"username": "centre1", "password": "centrepass"},
+        follow_redirects=False,
+    )
+    assert login_response.status_code == 302
+
+    applications_db.append(
+        {
+            "id": 9999,
+            "awarding_organisation": "Example AO",
+            "rn": "AO-1",
+            "qualification_number": "QUAL-001",
+            "qualification_title": "Level 3 Diploma in Teaching",
+            "status": "Approved",
+        }
+    )
+
+    try:
+        csv_payload = (
+            "learner_id,learner_name,qualification_id,qualification_title,registration_status\n"
+            "L-001,Alice Smith,QUAL-001,Level 3 Diploma in Teaching,active\n"
+            "L-002,Bob Jones,QUAL-404,Unknown Qualification,pending\n"
+        )
+        response = client.post(
+            "/integrations/lms-mis/upload",
+            files={"file": ("learners.csv", io.BytesIO(csv_payload.encode("utf-8")), "text/csv")},
+        )
+
+        assert response.status_code == 200
+        assert "2 learner records processed" in response.text
+        assert "1 matched approved qualifications" in response.text
+        assert "1 flagged as not approved for this centre" in response.text
+        assert "Eligible" in response.text
+        assert "Not Approved" in response.text
+    finally:
+        applications_db.pop()
+        lms_mis_integrations.clear()
+        lms_mis_assessment_runs.clear()


### PR DESCRIPTION
### Motivation

- Provide centres with a high-level integration point so their LMS/MIS learner records can be uploaded and automatically checked against the qualifications the centre is approved to deliver.

### Description

- Add an LMS/MIS integration area with new in-memory stores `lms_mis_integrations` and `lms_mis_assessment_runs`, qualification-normalisation helpers, and an assessment engine that marks uploaded learner rows as `eligible_for_delivery` or `not_approved_for_centre` based on approved qualifications. (`app/main.py`)
- Expose three secured routes: `GET /integrations/lms-mis` (integration hub UI), `POST /integrations/lms-mis/configure` (save connector metadata), and `POST /integrations/lms-mis/upload` (CSV upload + assessment). (`app/main.py`)
- Add a navigation link to the main menu and a new template `templates/lms_mis_integration.html` implementing configuration, CSV upload UI, and per-upload summary/results table. (`templates/base.html`, `templates/lms_mis_integration.html`)
- Add a focused test exercising auth protection and the CSV assessment workflow. (`tests/test_lms_mis_integration.py`)

### Testing

- Ran `python -m compileall app/main.py tests/test_lms_mis_integration.py`, which succeeded. 
- Attempted to run `PYTHONPATH=. pytest -q tests/test_lms_mis_integration.py` and `pytest -q tests/test_lms_mis_integration.py`; test collection failed because importing the app attempts to connect to the configured PostgreSQL database host (`postgres.railway.internal`) which is not resolvable in this execution environment, so the automated pytest run could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce740a70b4832c85017bfa0accdf77)